### PR TITLE
feat: add public key validation, --quiet flag, and network switch command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,8 @@
 pub mod completions;
+pub mod contract;
 pub mod deploy;
 pub mod info;
+pub mod network;
 pub mod new;
-pub mod wallet;
 pub mod tx;
-pub mod contract;
+pub mod wallet;

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -1,0 +1,55 @@
+use crate::utils::{config, print as p};
+use anyhow::Result;
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum NetworkCommands {
+    /// Show the current active network
+    Show,
+    /// Switch the active network (testnet or mainnet)
+    Switch {
+        /// Target network to switch to
+        #[arg(value_parser = ["testnet", "mainnet"])]
+        network: String,
+    },
+}
+
+pub fn handle(cmd: NetworkCommands) -> Result<()> {
+    match cmd {
+        NetworkCommands::Show => show(),
+        NetworkCommands::Switch { network } => switch(network),
+    }
+}
+
+fn show() -> Result<()> {
+    let cfg = config::load()?;
+    p::info(&format!("Active network: {}", cfg.network));
+    Ok(())
+}
+
+fn switch(target: String) -> Result<()> {
+    let mut cfg = config::load()?;
+
+    // Check if already on the target network
+    if cfg.network == target {
+        p::info(&format!("Already on {}. No changes made.", target));
+        return Ok(());
+    }
+
+    let previous = cfg.network.clone();
+    cfg.network = target.clone();
+    config::save(&cfg)?;
+
+    // Print mainnet warning
+    if target == "mainnet" {
+        p::warn("You are now on MAINNET. Transactions use real funds!");
+        p::warn("Double-check all addresses and amounts before sending.");
+    }
+
+    p::success(&format!(
+        "Network switched from {} to {}.",
+        previous, target
+    ));
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,10 @@ use colored::*;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+
+    /// Suppress the ASCII banner and decorative output
+    #[arg(long, short = 'q', global = true)]
+    quiet: bool,
 }
 
 #[derive(Subcommand)]
@@ -32,13 +36,19 @@ enum Commands {
     /// Show starforge config and environment info
     Info,
 
-    Tx(commands::tx::TxArgs),   // fetch transaction for the account 
-    
+    Tx(commands::tx::TxArgs),   // fetch transaction for the account
+
+    /// View or switch the active network (testnet/mainnet)
+    #[command(subcommand)]
+    Network(commands::network::NetworkCommands),
 }
 
 fn main() {
-    print_banner();
     let cli = Cli::parse();
+
+    if !cli.quiet {
+        print_banner();
+    }
 
     let result = match cli.command {
         Commands::Wallet(cmd)  => commands::wallet::handle(cmd),
@@ -47,6 +57,7 @@ fn main() {
         Commands::Deploy(args) => commands::deploy::handle(args),
         Commands::Info         => commands::info::handle(),
         Commands::Tx(args) => commands::tx::handle(args),
+        Commands::Network(cmd) => commands::network::handle(cmd),
     };
 
     if let Err(e) = result {

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -3,6 +3,42 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+/// Validates that a string is a well-formed Stellar Ed25519 public key.
+///
+/// A valid Stellar public key:
+/// - Starts with 'G'
+/// - Is exactly 56 characters long
+/// - Contains only valid base32 characters (A-Z, 2-7)
+///
+/// Returns `Ok(())` if the key is valid, or an error with a descriptive message.
+pub fn validate_public_key(key: &str) -> Result<()> {
+    if !key.starts_with('G') {
+        anyhow::bail!(
+            "Invalid public key: must start with 'G'.\n  \
+             A valid Stellar public key looks like: GABC...XYZ (56 characters, starting with G)."
+        );
+    }
+
+    if key.len() != 56 {
+        anyhow::bail!(
+            "Invalid public key: expected 56 characters, got {}.\n  \
+             A valid Stellar public key is exactly 56 characters long.",
+            key.len()
+        );
+    }
+
+    // Validate base32 character set (A-Z, 2-7)
+    if let Some(bad_char) = key.chars().find(|c| !matches!(c, 'A'..='Z' | '2'..='7')) {
+        anyhow::bail!(
+            "Invalid public key: contains invalid character '{}'.\n  \
+             A valid Stellar public key uses only uppercase letters A-Z and digits 2-7.",
+            bad_char
+        );
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub network: String,
@@ -47,6 +83,46 @@ pub fn load() -> Result<Config> {
     let config: Config = toml::from_str(&contents)
         .with_context(|| "Failed to parse config file")?;
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_public_key() {
+        // Well-formed Stellar public key (56 chars, starts with G, valid base32)
+        let key = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+        assert!(validate_public_key(key).is_ok());
+    }
+
+    #[test]
+    fn test_rejects_key_not_starting_with_g() {
+        let key = "SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+        let err = validate_public_key(key).unwrap_err();
+        assert!(err.to_string().contains("must start with 'G'"));
+    }
+
+    #[test]
+    fn test_rejects_key_wrong_length() {
+        let key = "GAAZI4TCR3TY5";
+        let err = validate_public_key(key).unwrap_err();
+        assert!(err.to_string().contains("expected 56 characters"));
+    }
+
+    #[test]
+    fn test_rejects_key_invalid_characters() {
+        // Lowercase letters are not valid base32
+        let key = "Gaazi4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+        let err = validate_public_key(key).unwrap_err();
+        assert!(err.to_string().contains("invalid character"));
+    }
+
+    #[test]
+    fn test_rejects_empty_key() {
+        let err = validate_public_key("").unwrap_err();
+        assert!(err.to_string().contains("must start with 'G'"));
+    }
 }
 
 pub fn save(config: &Config) -> Result<()> {


### PR DESCRIPTION
## Summary

- Added `validate_public_key()` function to `utils/config.rs` that checks Stellar public keys start with 'G', are exactly 56 characters, and contain only valid base32 characters (A-Z, 2-7), with clear error messages explaining the expected format
- Added global `--quiet` / `-q` flag to the CLI that suppresses the ASCII banner for use in scripts, CI pipelines, and piped output while preserving essential command output
- Added `starforge network show` command to display the current active network, and `starforge network switch <testnet|mainnet>` command to update the config file with a prominent warning when switching to mainnet

## Test plan

- [ ] `starforge --quiet wallet list` suppresses the banner
- [ ] `starforge -q info` suppresses the banner
- [ ] Essential output still prints with `--quiet`
- [ ] `starforge network show` prints the current network
- [ ] `starforge network switch testnet` works and confirms the switch
- [ ] `starforge network switch mainnet` prints a mainnet warning
- [ ] Switching to the already-active network prints a friendly message
- [ ] `validate_public_key` accepts valid G-prefixed 56-char base32 keys
- [ ] `validate_public_key` rejects keys not starting with G
- [ ] `validate_public_key` rejects keys with wrong length
- [ ] `validate_public_key` rejects keys with invalid characters (lowercase, digits 0-1, 8-9)
- [ ] Unit tests pass: `cargo test config::tests`

Closes #3
Closes #5
Closes #6