### PR TITLE
feat: enhance tx history with filtering, pagination, and memo decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +204,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -455,7 +477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -705,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +746,27 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "fuzzy-matcher"
@@ -751,13 +800,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -770,6 +831,25 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -842,6 +922,86 @@ dependencies = [
  "libc",
  "pkg-config",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1119,6 +1279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1307,42 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -1192,13 +1397,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1207,6 +1435,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1324,6 +1558,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1335,8 +1575,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1346,7 +1596,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1356,6 +1616,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1376,6 +1645,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1528,6 +1806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1843,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1629,6 +1919,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,7 +1990,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1698,10 +2000,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "spin"
@@ -1745,12 +2069,14 @@ dependencies = [
  "hidapi",
  "indicatif",
  "libloading",
- "rand",
+ "mockito",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
  "stellar-strkey",
  "stellar-xdr",
+ "tempfile",
  "toml",
  "ureq",
  "urlencoding",
@@ -1916,6 +2242,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +2301,25 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/src/commands/tx.rs
+++ b/src/commands/tx.rs
@@ -16,14 +16,29 @@ pub enum TxCommands {
     Send(SendArgs),
     /// Fetch and display recent transactions for a Stellar account
     History {
+        /// Account public key
         public_key: String,
-
-        /// number of transactions
+        /// Number of transactions to fetch (max 200)
         #[arg(short, long, default_value_t = 10)]
         limit: u8,
-
+        /// Network to use
         #[arg(short, long)]
         network: Option<String>,
+        /// Pagination cursor (paging_token from previous result)
+        #[arg(long)]
+        cursor: Option<String>,
+        /// Filter: only show transactions after this date (ISO 8601, e.g. 2024-01-01)
+        #[arg(long)]
+        after: Option<String>,
+        /// Filter: only show transactions before this date (ISO 8601, e.g. 2024-12-31)
+        #[arg(long)]
+        before: Option<String>,
+        /// Filter: only show successful transactions
+        #[arg(long)]
+        successful: bool,
+        /// Show full transaction details including memo
+        #[arg(long)]
+        details: bool,
     },
 }
 
@@ -56,7 +71,12 @@ pub fn handle(args: TxArgs) -> Result<()> {
             public_key,
             limit,
             network,
-        } => handle_history(public_key, limit, network),
+            cursor,
+            after,
+            before,
+            successful,
+            details,
+        } => handle_history(public_key, limit, network, cursor, after, before, successful, details),
     }
 }
 
@@ -214,8 +234,17 @@ fn parse_asset(asset: &str) -> Result<(Option<String>, Option<String>)> {
     }
 }
 
-fn handle_history(public_key: String, limit: u8, network_override: Option<String>) -> Result<()> {
-    let limit = limit.min(50);
+fn handle_history(
+    public_key: String,
+    limit: u8,
+    network_override: Option<String>,
+    cursor: Option<String>,
+    after: Option<String>,
+    before: Option<String>,
+    successful_only: bool,
+    details: bool,
+) -> Result<()> {
+    let limit = limit.min(200);
 
     config::validate_public_key(&public_key)?;
 
@@ -230,10 +259,34 @@ fn handle_history(public_key: String, limit: u8, network_override: Option<String
     println!("  {} {}", "◆".cyan().bold(), "Transaction History".white().bold());
     println!("  {} {}", "Account :".dimmed(), public_key.yellow());
     println!("  {} {}", "Network :".dimmed(), network.cyan());
-    println!("  {} {}", "Showing :".dimmed(), format!("last {} txs", limit).white());
+    println!("  {} {}", "Showing :".dimmed(), format!("up to {} txs", limit).white());
+
+    if after.is_some() || before.is_some() {
+        let range = format!(
+            "{} → {}",
+            after.as_deref().unwrap_or("*"),
+            before.as_deref().unwrap_or("*")
+        );
+        println!("  {} {}", "Range   :".dimmed(), range.white());
+    }
+    if successful_only {
+        println!("  {} {}", "Filter  :".dimmed(), "successful only".white());
+    }
+    if cursor.is_some() {
+        println!("  {} {}", "Cursor  :".dimmed(), "paginating from cursor".white());
+    }
+
     println!("  {}", "─".repeat(72).dimmed());
 
-    match horizon::fetch_transactions(&public_key, &network, limit) {
+    let filter = horizon::TxFilter {
+        limit,
+        cursor,
+        after,
+        before,
+        successful_only: if successful_only { Some(true) } else { None },
+    };
+
+    match horizon::fetch_transactions_filtered(&public_key, &network, filter) {
         Err(e) => {
             println!("\n  {} {}\n", "✗".red().bold(), e.to_string().red());
         }
@@ -241,15 +294,25 @@ fn handle_history(public_key: String, limit: u8, network_override: Option<String
             println!("\n  {} No transactions found for this account.\n", "!".yellow().bold());
         }
         Ok(txs) => {
-            print_transactions(&txs, &network);
+            print_transactions(&txs, &network, details);
         }
     }
 
     Ok(())
 }
 
-fn print_transactions(txs: &[horizon::TransactionRecord], network: &str) {
-    
+fn decode_memo(memo_type: Option<&str>, memo: Option<&str>) -> String {
+    match (memo_type, memo) {
+        (Some("text"), Some(m)) => format!("\"{}\"", m),
+        (Some("id"), Some(m)) => format!("id:{}", m),
+        (Some("hash"), Some(m)) => format!("hash:{}", &m[..m.len().min(16)]),
+        (Some("return"), Some(m)) => format!("return:{}", &m[..m.len().min(16)]),
+        (Some("none"), _) | (None, _) => "none".to_string(),
+        _ => "—".to_string(),
+    }
+}
+
+fn print_transactions(txs: &[horizon::TransactionRecord], network: &str, details: bool) {
     println!(
         "  {:<14}  {:<6}  {:<4}  {:<12}  {}",
         "Hash".dimmed(),
@@ -269,7 +332,6 @@ fn print_transactions(txs: &[horizon::TransactionRecord], network: &str) {
             "✗ fail".red().to_string()
         };
 
-        // returns fee in stroops; 1 XLM is equal to 10_000_000 stroops
         let fee_xlm = tx
             .fee_charged
             .parse::<f64>()
@@ -291,11 +353,30 @@ fn print_transactions(txs: &[horizon::TransactionRecord], network: &str) {
             fee_xlm.yellow(),
             ts.dimmed(),
         );
+
+        if details {
+            if let Some(ref src) = tx.source_account {
+                println!("  {:<14}  {}", "".dimmed(), format!("src: {}…", &src[..16]).dimmed());
+            }
+            let memo = decode_memo(tx.memo_type.as_deref(), tx.memo.as_deref());
+            println!("  {:<14}  {}", "".dimmed(), format!("memo: {}", memo).dimmed());
+        }
     }
 
     println!("  {}", "─".repeat(72).dimmed());
 
-    // footer === Stellar Expert deep link
+    // Pagination hint
+    if let Some(last) = txs.last() {
+        if let Some(ref token) = last.paging_token {
+            println!(
+                "\n  {} {}",
+                "Next page:".dimmed(),
+                format!("--cursor {}", token).cyan()
+            );
+        }
+    }
+
+    // Explorer deep link
     let explorer_base = if network == "mainnet" {
         "https://stellar.expert/explorer/public/tx"
     } else {

--- a/src/utils/horizon.rs
+++ b/src/utils/horizon.rs
@@ -53,13 +53,17 @@ pub fn check_network(network: &str) -> bool {
     ureq::get(&url).call().map(|r| r.status() == 200).unwrap_or(false)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct TransactionRecord {
     pub hash: String,
     pub successful: bool,
     pub operation_count: u32,
     pub fee_charged: String,
     pub created_at: String,
+    pub memo_type: Option<String>,
+    pub memo: Option<String>,
+    pub source_account: Option<String>,
+    pub paging_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,17 +77,45 @@ struct TransactionsEmbedded {
     records: Vec<TransactionRecord>,
 }
 
+pub struct TxFilter {
+    pub limit: u8,
+    pub cursor: Option<String>,
+    pub after: Option<String>,
+    pub before: Option<String>,
+    pub successful_only: Option<bool>,
+}
+
+#[allow(dead_code)]
 pub fn fetch_transactions(
     public_key: &str,
     network: &str,
     limit: u8,
 ) -> Result<Vec<TransactionRecord>> {
-    let url = format!(
+    fetch_transactions_filtered(public_key, network, TxFilter {
+        limit,
+        cursor: None,
+        after: None,
+        before: None,
+        successful_only: None,
+    })
+}
+
+pub fn fetch_transactions_filtered(
+    public_key: &str,
+    network: &str,
+    filter: TxFilter,
+) -> Result<Vec<TransactionRecord>> {
+    let limit = filter.limit.min(200);
+    let mut url = format!(
         "{}/accounts/{}/transactions?order=desc&limit={}",
         horizon_url(network),
         public_key,
         limit
     );
+
+    if let Some(ref cursor) = filter.cursor {
+        url.push_str(&format!("&cursor={}", cursor));
+    }
 
     let res = ureq::get(&url).call().with_context(|| {
         format!(
@@ -96,7 +128,20 @@ pub fn fetch_transactions(
         .into_json()
         .with_context(|| "Failed to parse transactions response")?;
 
-    Ok(parsed.embedded.records)
+    let mut records = parsed.embedded.records;
+
+    // Client-side date filtering (Horizon doesn't support date range natively)
+    if let Some(ref after) = filter.after {
+        records.retain(|tx| tx.created_at.as_str() >= after.as_str());
+    }
+    if let Some(ref before) = filter.before {
+        records.retain(|tx| tx.created_at.as_str() <= before.as_str());
+    }
+    if let Some(successful_only) = filter.successful_only {
+        records.retain(|tx| tx.successful == successful_only);
+    }
+
+    Ok(records)
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Closes #33 

## Summary

The existing `starforge tx history` command was minimal — no filtering, no pagination, and no transaction details. This PR enhances it with date range filtering, pagination support, memo decoding, and a `--details` flag for expanded output.

## Changes

### `src/commands/tx.rs`
- Added `--cursor` flag for pagination using Horizon's `paging_token`
- Added `--after` / `--before` flags for date range filtering (ISO 8601)
- Added `--successful` flag to filter to successful transactions only
- Added `--details` flag to expand each row with source account and decoded memo
- Raised the max transaction limit from 50 to 200
- Prints a next-page cursor hint at the bottom of results for easy pagination

### `src/utils/horizon.rs`
- Extended `TransactionRecord` with `memo`, `memo_type`, `source_account`, and `paging_token` fields
- Added `TxFilter` struct to encapsulate filter parameters
- Added `fetch_transactions_filtered()` with cursor and client-side date/status filtering
- Kept `fetch_transactions()` as a convenience wrapper for backward compatibility

## Usage

```bash
# Basic history
starforge tx history <public_key>

# Date range filter
starforge tx history <public_key> --after 2024-01-01 --before 2024-12-31

# Successful transactions only with expanded details
starforge tx history <public_key> --successful --details

# Pagination — grab cursor from previous output
starforge tx history <public_key> --limit 10
starforge tx history <public_key> --limit 10 --cursor <paging_token>
