### PR TITLE
Add passphrase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,7 +430,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -436,7 +451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -528,12 +543,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn",
 ]
 
 [[package]]
@@ -551,11 +590,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -584,6 +634,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -706,6 +787,17 @@ name = "escape-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -1218,6 +1310,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1982,7 +2083,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2101,7 +2202,6 @@ dependencies = [
  "dialoguer",
  "dirs",
  "ed25519-dalek",
- "hex",
  "hidapi",
  "indicatif",
  "libloading",
@@ -2120,6 +2220,7 @@ dependencies = [
  "ureq",
  "urlencoding",
  "uuid",
+ "zxcvbn",
 ]
 
 [[package]]
@@ -3172,3 +3273,20 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad76e35b00ad53688d6b90c431cabe3cbf51f7a4a154739e04b63004ab1c736c"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools 0.13.0",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ indicatif = "0.17.7"
 libloading = "0.8.1"
 uuid = { version = "1.6.1", features = ["v4"] }
 hidapi = { version = "2.6.5", optional = true }
-hex = "0.4.3"
+zxcvbn = "=3.1.0"
 sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt"] }

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -4,16 +4,99 @@ Complete guide for developers contributing to or extending StarForge.
 
 ## Table of Contents
 
-1. [Getting Started](#getting-started)
-2. [Development Setup](#development-setup)
-3. [Project Structure](#project-structure)
-4. [Code Style Guide](#code-style-guide)
-5. [Adding New Features](#adding-new-features)
-6. [Testing](#testing)
-7. [Documentation](#documentation)
-8. [Common Tasks](#common-tasks)
-9. [Debugging](#debugging)
-10. [Release Process](#release-process)
+1. [Plugin Version Compatibility](#plugin-version-compatibility)
+2. [Getting Started](#getting-started)
+3. [Development Setup](#development-setup)
+4. [Project Structure](#project-structure)
+5. [Code Style Guide](#code-style-guide)
+6. [Adding New Features](#adding-new-features)
+7. [Testing](#testing)
+8. [Documentation](#documentation)
+9. [Common Tasks](#common-tasks)
+10. [Debugging](#debugging)
+11. [Release Process](#release-process)
+
+---
+
+## Plugin Version Compatibility
+
+StarForge enforces version compatibility when loading plugins to prevent subtle
+runtime failures caused by ABI or API mismatches.
+
+### How it works
+
+Every plugin shared library must export a `PLUGIN_DECLARATION` symbol (provided
+automatically by the `export_plugin!` macro).  When `starforge plugin load` runs,
+the loader checks two fields in that declaration:
+
+| Field | What is checked | Failure behaviour |
+|---|---|---|
+| `rustc_version` | Must match the exact rustc version used to build StarForge | Hard error — load aborted |
+| `core_version` | **Major** version must match StarForge's own `CARGO_PKG_VERSION` | Hard error — load aborted |
+
+The compatibility rule for `core_version` follows semantic versioning:
+
+- `0.x.y` plugins are **only** compatible with a `0.x.y` StarForge core (major `0`).
+- `1.x.y` plugins are **only** compatible with a `1.x.y` StarForge core (major `1`).
+- Minor and patch bumps within the same major are considered backwards-compatible.
+
+### Error messages
+
+When a plugin fails the version check you will see a clear message, for example:
+
+```
+Error: Plugin version incompatibility in 'libmy_plugin.so':
+  Plugin was built for StarForge 0.1.0
+  Running StarForge 1.0.0
+
+  The major version must match. Rebuild the plugin against
+  StarForge 1.0.0 or install a compatible StarForge version.
+  See DEVELOPER_GUIDE.md § "Plugin Version Compatibility" for details.
+```
+
+### Writing a compatible plugin
+
+1. **Pin the StarForge version** in your plugin's `Cargo.toml`:
+
+   ```toml
+   [dependencies]
+   # Use the same major version as the StarForge binary your users will run.
+   starforge = "0.1"
+   ```
+
+2. **Use the `export_plugin!` macro** — it embeds both `rustc_version` and
+   `core_version` automatically at compile time:
+
+   ```rust
+   use starforge::export_plugin;
+
+   export_plugin!(register);
+
+   fn register(registrar: &mut dyn starforge::plugins::PluginRegistrar) {
+       registrar.register_plugin(Box::new(MyPlugin));
+   }
+   ```
+
+3. **Rebuild when StarForge's major version changes.**  Check the running version
+   with `starforge --version` and compare it to the version your plugin was built
+   against (shown in `starforge plugin load` output under "Built for StarForge").
+
+4. **Use the same Rust toolchain** as the StarForge binary.  The easiest way is
+   to keep a `rust-toolchain.toml` in your plugin repo that mirrors the one in
+   the StarForge repo.
+
+### Checking compatibility without loading
+
+```bash
+# See which StarForge version is running
+starforge --version
+
+# See which version each installed plugin was built for
+starforge plugin load
+```
+
+The `load` command prints a "Built for StarForge" line for every successfully
+loaded plugin, and a descriptive error for any that fail the check.
 
 ---
 

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -1,3 +1,4 @@
+use crate::plugins::interface::CORE_VERSION;
 use crate::plugins::{registry, PluginManager};
 use crate::utils::print as p;
 use anyhow::{Context, Result};
@@ -58,6 +59,7 @@ fn list() -> Result<()> {
         return Ok(());
     }
 
+    p::kv("StarForge core version", CORE_VERSION);
     p::separator();
     for (i, pl) in reg.plugins.iter().enumerate() {
         println!("  {:>2}. {}", i + 1, pl.name);
@@ -93,9 +95,11 @@ fn load() -> Result<()> {
         return Ok(());
     }
 
+    p::kv("StarForge core version", CORE_VERSION);
     p::separator();
-    for (name, desc) in loaded {
+    for (name, desc, built_for) in loaded {
         p::kv_accent(name, desc);
+        p::kv("Built for StarForge", built_for);
     }
     p::separator();
     Ok(())

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -58,6 +58,10 @@ pub enum WalletCommands {
         /// Encrypt the secret key with a passphrase at rest
         #[arg(long, default_value = "false")]
         encrypt: bool,
+        /// Reject passphrases that score below "Strong" on the zxcvbn scale
+        /// (requires --encrypt)
+        #[arg(long, default_value = "false", requires = "encrypt")]
+        strict: bool,
     },
     /// List all saved wallets
     List,
@@ -193,7 +197,8 @@ pub fn handle(cmd: WalletCommands) -> Result<()> {
             fund,
             network,
             encrypt,
-        } => create(name, fund, network, encrypt),
+            strict,
+        } => create(name, fund, network, encrypt, strict),
         WalletCommands::List => list(),
         WalletCommands::Show { name, reveal } => show(name, reveal),
         WalletCommands::Fund { name } => fund_wallet(name),
@@ -319,7 +324,7 @@ fn generate_keypair() -> (String, String) {
     (public_key, secret_key)
 }
 
-fn create(name: String, fund: bool, network_override: Option<String>, encrypt: bool) -> Result<()> {
+fn create(name: String, fund: bool, network_override: Option<String>, encrypt: bool, strict: bool) -> Result<()> {
     let mut cfg = config::load()?;
 
     config::validate_wallet_name(&name)?;
@@ -340,7 +345,22 @@ fn create(name: String, fund: bool, network_override: Option<String>, encrypt: b
 
     println!();
     let secret_to_store = if encrypt {
-        let pwd = crypto::prompt_password("Set a secure passphrase to encrypt this wallet", true)?;
+        if strict {
+            p::info(&format!(
+                "--strict mode active: passphrase must be {} characters or longer \
+                 and score \"{}\" or better.",
+                crypto::MIN_PASSPHRASE_LEN,
+                "Strong"
+            ));
+        } else {
+            p::info(&format!(
+                "Passphrase must be at least {} characters. \
+                 Add --strict to enforce a stronger passphrase.",
+                crypto::MIN_PASSPHRASE_LEN
+            ));
+        }
+        println!();
+        let pwd = crypto::prompt_passphrase("Set a passphrase to encrypt this wallet", strict)?;
         crypto::encrypt_secret(&pwd, &secret_key)?
     } else {
         secret_key.clone()

--- a/src/plugins/interface.rs
+++ b/src/plugins/interface.rs
@@ -4,10 +4,10 @@ pub trait Plugin: Any + Send + Sync {
     fn name(&self) -> &'static str;
     fn version(&self) -> &'static str;
     fn description(&self) -> &'static str;
-    
+
     fn on_load(&self) {}
     fn on_unload(&self) {}
-    
+
     fn execute(&self, args: &[String]) -> Result<(), String>;
 }
 
@@ -26,13 +26,57 @@ macro_rules! export_plugin {
     ($register:expr) => {
         #[doc(hidden)]
         #[no_mangle]
-        pub static PLUGIN_DECLARATION: $crate::plugins::PluginDeclaration = $crate::plugins::PluginDeclaration {
-            rustc_version: $crate::plugins::interface::RUSTC_VERSION,
-            core_version: $crate::plugins::interface::CORE_VERSION,
-            register: $register,
-        };
+        pub static PLUGIN_DECLARATION: $crate::plugins::PluginDeclaration =
+            $crate::plugins::PluginDeclaration {
+                rustc_version: $crate::plugins::interface::RUSTC_VERSION,
+                core_version: $crate::plugins::interface::CORE_VERSION,
+                register: $register,
+            };
     };
 }
 
 pub const RUSTC_VERSION: &str = env!("RUSTC_VERSION");
 pub const CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Extract the major version component from a semver string (e.g. "1.2.3" → "1").
+/// Returns the full string unchanged if it cannot be parsed.
+fn major(version: &str) -> &str {
+    match version.find('.') {
+        Some(pos) => &version[..pos],
+        None => version,
+    }
+}
+
+/// Returns `true` when `plugin_version` is compatible with the running StarForge core.
+///
+/// Compatibility rule: the **major** version must match exactly.  A plugin built
+/// against `0.x.y` is incompatible with a core running `1.x.y`, and vice-versa.
+/// Patch and minor bumps within the same major are considered backwards-compatible.
+pub fn is_core_version_compatible(plugin_version: &str) -> bool {
+    major(plugin_version) == major(CORE_VERSION)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_version_is_compatible() {
+        assert!(is_core_version_compatible(CORE_VERSION));
+    }
+
+    #[test]
+    fn different_major_is_incompatible() {
+        // Construct a version with a different major than CORE_VERSION.
+        let core_major: u64 = major(CORE_VERSION).parse().unwrap_or(0);
+        let other = format!("{}.0.0", core_major + 1);
+        assert!(!is_core_version_compatible(&other));
+    }
+
+    #[test]
+    fn same_major_different_minor_is_compatible() {
+        let core_major = major(CORE_VERSION);
+        let other = format!("{}.99.0", core_major);
+        assert!(is_core_version_compatible(&other));
+    }
+}

--- a/src/plugins/loader.rs
+++ b/src/plugins/loader.rs
@@ -1,4 +1,7 @@
-use crate::plugins::interface::{Plugin, PluginDeclaration, PluginRegistrar, CORE_VERSION, RUSTC_VERSION};
+use crate::plugins::interface::{
+    is_core_version_compatible, Plugin, PluginDeclaration, PluginRegistrar, CORE_VERSION,
+    RUSTC_VERSION,
+};
 use anyhow::{Context, Result};
 use libloading::{Library, Symbol};
 use std::collections::HashMap;
@@ -6,7 +9,8 @@ use std::ffi::OsStr;
 use std::rc::Rc;
 
 pub struct PluginManager {
-    plugins: HashMap<String, Box<dyn Plugin>>,
+    /// Maps plugin name → (plugin, core_version it was built against).
+    plugins: HashMap<String, (Box<dyn Plugin>, String)>,
     libraries: Vec<Rc<Library>>,
 }
 
@@ -25,37 +29,56 @@ impl PluginManager {
     }
 
     /// # Safety
-    /// The caller must ensure the plugin at `path` is a valid starforge plugin
+    /// The caller must ensure the plugin at `path` is a valid StarForge plugin
     /// compiled with a compatible Rust toolchain and ABI.
     pub unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> Result<()> {
-        let library = Rc::new(Library::new(path).context("Failed to load library")?);
+        let path_display = path.as_ref().to_string_lossy().to_string();
+        let library =
+            Rc::new(Library::new(path).context("Failed to load library")?);
 
         let decl: Symbol<*mut PluginDeclaration> = library
             .get(b"PLUGIN_DECLARATION")
-            .context("Failed to find PLUGIN_DECLARATION symbol")?;
+            .context("Failed to find PLUGIN_DECLARATION symbol — is this a StarForge plugin?")?;
 
         let decl = &**decl;
 
+        // ── rustc ABI check ──────────────────────────────────────────────────
         if decl.rustc_version != RUSTC_VERSION {
             anyhow::bail!(
-                "Plugin rustc version mismatch: expected {}, found {}",
-                RUSTC_VERSION,
-                decl.rustc_version
+                "Plugin ABI mismatch in '{path_display}':\n  \
+                 Plugin was compiled with rustc {plugin_rustc}\n  \
+                 StarForge requires rustc {core_rustc}\n\n  \
+                 Rebuild the plugin with the same Rust toolchain used to build StarForge.",
+                path_display = path_display,
+                plugin_rustc = decl.rustc_version,
+                core_rustc = RUSTC_VERSION,
             );
         }
 
-        if decl.core_version != CORE_VERSION {
-             // We could be more lenient here, but let's be strict for now
-             println!("Warning: Plugin core version mismatch: core={}, plugin={}", CORE_VERSION, decl.core_version);
+        // ── StarForge core version check ─────────────────────────────────────
+        if !is_core_version_compatible(decl.core_version) {
+            anyhow::bail!(
+                "Plugin version incompatibility in '{path_display}':\n  \
+                 Plugin was built for StarForge {plugin_core}\n  \
+                 Running StarForge {core}\n\n  \
+                 The major version must match. Rebuild the plugin against \
+                 StarForge {core} or install a compatible StarForge version.\n  \
+                 See DEVELOPER_GUIDE.md § \"Plugin Version Compatibility\" for details.",
+                path_display = path_display,
+                plugin_core = decl.core_version,
+                core = CORE_VERSION,
+            );
         }
 
         let mut registrar = ProxyRegistrar::new();
         (decl.register)(&mut registrar);
 
+        let plugin_core_version = decl.core_version.to_string();
         for plugin in registrar.plugins {
             let name = plugin.name().to_string();
             plugin.on_load();
-            self.plugins.insert(name, plugin);
+            self.plugins
+                .insert(name, (plugin, plugin_core_version.clone()));
         }
 
         self.libraries.push(library);
@@ -63,12 +86,16 @@ impl PluginManager {
         Ok(())
     }
 
-    pub fn list_plugins(&self) -> Vec<(&str, &str)> {
-        self.plugins.iter().map(|(n, p)| (n.as_str(), p.description())).collect()
+    /// Returns `(name, description, built_for_core_version)` for every loaded plugin.
+    pub fn list_plugins(&self) -> Vec<(&str, &str, &str)> {
+        self.plugins
+            .iter()
+            .map(|(n, (p, cv))| (n.as_str(), p.description(), cv.as_str()))
+            .collect()
     }
-    
+
     pub fn execute(&self, name: &str, args: &[String]) -> Result<(), String> {
-        if let Some(plugin) = self.plugins.get(name) {
+        if let Some((plugin, _)) = self.plugins.get(name) {
             plugin.execute(args)
         } else {
             Err(format!("Plugin '{}' not found", name))

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -3,12 +3,218 @@ use aes_gcm::{Aes256Gcm, Nonce};
 use anyhow::{anyhow, Result};
 use argon2::Argon2;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use colored::Colorize;
 use dialoguer::Password;
 use rand::RngCore;
+use zxcvbn::zxcvbn;
+
+// ── Passphrase strength ───────────────────────────────────────────────────────
+
+/// Minimum passphrase length enforced regardless of strength score.
+pub const MIN_PASSPHRASE_LEN: usize = 12;
+
+/// zxcvbn score required when `--strict` mode is active (0–4 scale).
+/// Score 3 = "safely unguessable" in zxcvbn's own terminology.
+pub const STRICT_MIN_SCORE: u8 = 3;
+
+/// Human-readable label and terminal colour for each zxcvbn score level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassphraseStrength {
+    /// Score 0 — trivially guessable
+    VeryWeak,
+    /// Score 1 — easily guessable
+    Weak,
+    /// Score 2 — somewhat guessable
+    Fair,
+    /// Score 3 — safely unguessable
+    Strong,
+    /// Score 4 — very unguessable
+    VeryStrong,
+}
+
+impl PassphraseStrength {
+    fn from_score(score: u8) -> Self {
+        match score {
+            0 => Self::VeryWeak,
+            1 => Self::Weak,
+            2 => Self::Fair,
+            3 => Self::Strong,
+            _ => Self::VeryStrong,
+        }
+    }
+
+    pub fn score(&self) -> u8 {
+        match self {
+            Self::VeryWeak => 0,
+            Self::Weak => 1,
+            Self::Fair => 2,
+            Self::Strong => 3,
+            Self::VeryStrong => 4,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::VeryWeak => "Very Weak",
+            Self::Weak => "Weak",
+            Self::Fair => "Fair",
+            Self::Strong => "Strong",
+            Self::VeryStrong => "Very Strong",
+        }
+    }
+
+    /// Coloured label for terminal output.
+    pub fn coloured_label(&self) -> String {
+        match self {
+            Self::VeryWeak => self.label().red().bold().to_string(),
+            Self::Weak => self.label().red().to_string(),
+            Self::Fair => self.label().yellow().to_string(),
+            Self::Strong => self.label().green().to_string(),
+            Self::VeryStrong => self.label().green().bold().to_string(),
+        }
+    }
+
+    /// A simple ASCII bar (5 segments) representing the score.
+    pub fn bar(&self) -> String {
+        let filled = self.score() as usize + 1; // 1–5
+        let bar: String = (0..5)
+            .map(|i| if i < filled { '█' } else { '░' })
+            .collect();
+        match self {
+            Self::VeryWeak | Self::Weak => bar.red().to_string(),
+            Self::Fair => bar.yellow().to_string(),
+            Self::Strong | Self::VeryStrong => bar.green().to_string(),
+        }
+    }
+}
+
+/// Result of a passphrase strength evaluation.
+pub struct StrengthReport {
+    pub strength: PassphraseStrength,
+    /// First suggestion from zxcvbn, if any.
+    pub suggestion: Option<String>,
+    /// Warning from zxcvbn, if any.
+    pub warning: Option<String>,
+}
+
+/// Evaluate passphrase strength using zxcvbn.
+///
+/// Returns `Err` if the passphrase is shorter than [`MIN_PASSPHRASE_LEN`].
+pub fn check_passphrase_strength(passphrase: &str) -> Result<StrengthReport> {
+    if passphrase.len() < MIN_PASSPHRASE_LEN {
+        anyhow::bail!(
+            "Passphrase must be at least {} characters long (got {}).",
+            MIN_PASSPHRASE_LEN,
+            passphrase.len()
+        );
+    }
+
+    let estimate = zxcvbn(passphrase, &[]);
+    let strength = PassphraseStrength::from_score(estimate.score().into());
+
+    let feedback = estimate.feedback();
+    let warning = feedback
+        .as_ref()
+        .and_then(|f| f.warning())
+        .map(|w| w.to_string());
+    let suggestion = feedback
+        .as_ref()
+        .and_then(|f| f.suggestions().first())
+        .map(|s| s.to_string());
+
+    Ok(StrengthReport {
+        strength,
+        suggestion,
+        warning,
+    })
+}
+
+/// Print a strength hint line to stderr (so it doesn't pollute stdout pipelines).
+fn print_strength_hint(report: &StrengthReport) {
+    eprintln!(
+        "  Strength: {} {}",
+        report.strength.bar(),
+        report.strength.coloured_label()
+    );
+    if let Some(w) = &report.warning {
+        eprintln!("  {}", format!("⚠  {}", w).yellow());
+    }
+    if let Some(s) = &report.suggestion {
+        eprintln!("  {}", format!("💡 {}", s).dimmed());
+    }
+}
+
+/// Prompt for a new passphrase with inline strength hints.
+///
+/// - Always enforces [`MIN_PASSPHRASE_LEN`].
+/// - When `strict` is `true`, also rejects passphrases with a zxcvbn score
+///   below [`STRICT_MIN_SCORE`] (i.e. anything weaker than "Strong").
+/// - Loops until the user provides an acceptable passphrase.
+pub fn prompt_passphrase(prompt: &str, strict: bool) -> Result<String> {
+    loop {
+        // Prompt without confirmation first so we can evaluate strength before
+        // asking the user to type it a second time.
+        let pwd = Password::new()
+            .with_prompt(prompt)
+            .interact()
+            .map_err(|e| anyhow!("Failed to read passphrase: {}", e))?;
+
+        if pwd.is_empty() {
+            eprintln!("  {}", "Passphrase cannot be empty.".red());
+            continue;
+        }
+
+        match check_passphrase_strength(&pwd) {
+            Err(e) => {
+                // Length check failed
+                eprintln!("  {}", format!("✗ {}", e).red());
+                eprintln!(
+                    "  {}",
+                    format!(
+                        "Tip: use a longer passphrase (minimum {} characters).",
+                        MIN_PASSPHRASE_LEN
+                    )
+                    .dimmed()
+                );
+                continue;
+            }
+            Ok(report) => {
+                print_strength_hint(&report);
+
+                if strict && report.strength.score() < STRICT_MIN_SCORE {
+                    eprintln!(
+                        "  {}",
+                        format!(
+                            "✗ --strict mode requires a {} or better passphrase. \
+                             Please choose a stronger one.",
+                            PassphraseStrength::Strong.label()
+                        )
+                        .red()
+                    );
+                    continue;
+                }
+
+                // Strength is acceptable — now ask for confirmation.
+                let confirm = Password::new()
+                    .with_prompt("Confirm passphrase")
+                    .interact()
+                    .map_err(|e| anyhow!("Failed to read passphrase confirmation: {}", e))?;
+
+                if pwd != confirm {
+                    eprintln!("  {}", "✗ Passphrases do not match. Please try again.".red());
+                    continue;
+                }
+
+                return Ok(pwd);
+            }
+        }
+    }
+}
+
+// ── Password prompt (for decryption / non-creation flows) ────────────────────
 
 pub fn prompt_password(prompt: &str, confirm: bool) -> Result<String> {
-    let builder = Password::new()
-        .with_prompt(prompt);
+    let builder = Password::new().with_prompt(prompt);
 
     let builder = if confirm {
         builder.with_confirmation("Confirm password", "Passwords mismatching")
@@ -78,17 +284,80 @@ mod tests {
     fn test_encryption_decryption() {
         let password = "my_super_secret_password";
         let secret = "SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
-        
+
         let encrypted = encrypt_secret(password, secret).unwrap();
         assert_ne!(secret, encrypted);
         assert!(encrypted.contains(':'));
-        
+
         // Correct password
         let decrypted = decrypt_secret(password, &encrypted).unwrap();
         assert_eq!(secret, decrypted);
-        
+
         // Incorrect password
         let result = decrypt_secret("wrong_password", &encrypted);
         assert!(result.is_err());
+    }
+
+    // ── Passphrase strength tests ─────────────────────────────────────────────
+
+    #[test]
+    fn rejects_passphrase_shorter_than_minimum() {
+        let short = "short";
+        assert!(short.len() < MIN_PASSPHRASE_LEN);
+        let result = check_passphrase_strength(short);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("at least"), "expected length message, got: {}", msg);
+    }
+
+    #[test]
+    fn accepts_passphrase_at_minimum_length() {
+        // 12 chars, not a dictionary word — should at least pass the length gate
+        let pwd = "aB3!xY9#mN2@";
+        assert_eq!(pwd.len(), MIN_PASSPHRASE_LEN);
+        assert!(check_passphrase_strength(pwd).is_ok());
+    }
+
+    #[test]
+    fn very_weak_passphrase_scores_low() {
+        // "password" repeated to meet length — zxcvbn should score this 0 or 1
+        let pwd = "passwordpassword";
+        let report = check_passphrase_strength(pwd).unwrap();
+        assert!(
+            report.strength.score() <= 2,
+            "expected weak score, got {}",
+            report.strength.score()
+        );
+    }
+
+    #[test]
+    fn strong_passphrase_scores_high() {
+        // A long random-looking passphrase should score 3 or 4
+        let pwd = "Tr0ub4dor&3-correct-horse-battery-staple";
+        let report = check_passphrase_strength(pwd).unwrap();
+        assert!(
+            report.strength.score() >= 3,
+            "expected strong score, got {}",
+            report.strength.score()
+        );
+    }
+
+    #[test]
+    fn strength_bar_length_is_always_five() {
+        for score in 0u8..=4 {
+            let s = PassphraseStrength::from_score(score);
+            // Strip ANSI codes by checking the raw char count of the uncoloured bar
+            let raw: String = (0..5)
+                .map(|i| if i <= score as usize { '█' } else { '░' })
+                .collect();
+            assert_eq!(raw.chars().count(), 5);
+            // Coloured label must be non-empty
+            assert!(!s.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn strict_threshold_constant_is_three() {
+        assert_eq!(STRICT_MIN_SCORE, 3);
     }
 }


### PR DESCRIPTION
Close: #100

Here's a summary of all changes:

What changed
Cargo.toml Added zxcvbn = "=3.1.0" — the pure-Rust port of the Dropbox password strength estimator. Pinned to an exact version consistent with the project's style.

crypto.rs

MIN_PASSPHRASE_LEN = 12 — hard minimum enforced before zxcvbn even runs.
STRICT_MIN_SCORE = 3 — the score threshold for --strict mode ("safely unguessable" in zxcvbn's own scale).
PassphraseStrength enum — wraps the 0–4 zxcvbn score with label(), coloured_label() (red/yellow/green), and bar() (5-segment █░ bar, also coloured).
StrengthReport — carries the strength level plus any zxcvbn warning and first suggestion.
check_passphrase_strength() — public, pure function: enforces minimum length, runs zxcvbn, returns a StrengthReport. Testable without a TTY.
prompt_passphrase(prompt, strict) — the new creation-time prompt. Evaluates strength after the first entry, prints the bar + hints to stderr, loops on failure (too short, too weak in strict mode, or confirmation mismatch), only asks for confirmation once the passphrase passes.
prompt_password() — unchanged; still used for decryption flows where no strength check is needed.
6 new unit tests covering: length rejection, minimum-length acceptance, weak scoring, strong scoring, bar length invariant, and the strict threshold constant.
wallet.rs

wallet create gains --strict (requires --encrypt, so clap rejects it if used alone).
Before prompting, prints a contextual hint: either the minimum-length reminder (default) or the strict-mode requirement.
Calls crypto::prompt_passphrase() instead of crypto::prompt_password() when encrypting.