### PR TITLE
feat: add stablecoin and escrow built-in contract templates (#112)

### DIFF
--- a/QUICK_START_TEMPLATES.md
+++ b/QUICK_START_TEMPLATES.md
@@ -183,6 +183,19 @@ git --version
 starforge template show <template-name>
 ```
 
+## Built-in Templates
+
+These templates are available without initializing the marketplace:
+
+| Template | Command | Description |
+|----------|---------|-------------|
+| `hello-world` | `starforge new contract my-contract` | Basic contract with optional storage |
+| `token` | `starforge new contract my-token --template token` | Fungible token with mint/burn/transfer |
+| `nft` | `starforge new contract my-nft --template nft` | Non-fungible token with URI metadata |
+| `voting` | `starforge new contract my-vote --template voting` | DAO proposal and voting contract |
+| `stablecoin` | `starforge new contract my-stable --template stablecoin` | Pegged stablecoin with mint/burn |
+| `escrow` | `starforge new contract my-escrow --template escrow` | Three-party escrow with arbiter release/refund |
+
 ## Next Steps
 
 - Read the [full documentation](TEMPLATE_MARKETPLACE.md)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project is actively maintained and participates in the [Stellar Wave Progra
 Create and manage Stellar ed25519 keypairs locally. Generate cryptographically secure keys using proper Stellar strkey encoding (G... for public, S... for secret). Optionally encrypt keys at rest with AES-256-GCM. Fund testnet accounts via Friendbot, list all saved wallets, inspect live on-chain balances, and securely store keys in `~/.starforge/config.toml`.
 
 ### ◻ Project Scaffolding
-Scaffold new Soroban smart contract projects from battle-tested templates with one command. Choose from: `hello-world`, `token`, `nft`, and `voting`. Use interactive mode (`--interactive`) to customize contract options like author, license, storage type, and test inclusion. Also scaffolds full Stellar dApp frontends (Vite + React).
+Scaffold new Soroban smart contract projects from battle-tested templates with one command. Choose from: `hello-world`, `token`, `nft`, `voting`, `stablecoin`, and `escrow`. Use interactive mode (`--interactive`) to customize contract options like author, license, storage type, and test inclusion. Also scaffolds full Stellar dApp frontends (Vite + React).
 
 **NEW: Template Marketplace** - Discover and use community-contributed templates:
 ```bash
@@ -140,6 +140,8 @@ starforge new contract my-contract --interactive
 starforge new contract my-token --template token
 starforge new contract my-nft --template nft
 starforge new contract my-vote --template voting
+starforge new contract my-stable --template stablecoin
+starforge new contract my-escrow --template escrow
 
 # Search marketplace templates
 starforge template search defi

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -208,6 +208,8 @@ fn scaffold_contract(
         "token" => token_template(&name),
         "voting" => voting_template(&name),
         "nft" => nft_template(&name),
+        "stablecoin" => stablecoin_template(&name),
+        "escrow" => escrow_template(&name),
         _ => {
             if let Some(custom) = templates::template_source_content(&template)? {
                 custom
@@ -736,6 +738,190 @@ mod test {{
         
         let uri = client.token_uri(&1);
         assert_eq!(uri, String::from_str(&env, "ipfs://token1"));
+    }}
+}}
+"#, pascal = pascal)
+}
+
+fn stablecoin_template(name: &str) -> String {
+    let pascal = to_pascal(name);
+    format!(r#"#![no_std]
+use soroban_sdk::{{contract, contractimpl, contracttype, Address, Env, String}};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {{
+    Admin,
+    Balance(Address),
+    TotalSupply,
+    Pegged,
+}}
+
+#[contract]
+pub struct {pascal};
+
+#[contractimpl]
+impl {pascal} {{
+    pub fn initialize(env: Env, admin: Address, pegged_asset: String) {{
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Pegged, &pegged_asset);
+        env.storage().instance().set(&DataKey::TotalSupply, &0i128);
+    }}
+
+    pub fn mint(env: Env, to: Address, amount: i128) {{
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        let balance: i128 = env.storage().persistent().get(&DataKey::Balance(to.clone())).unwrap_or(0);
+        env.storage().persistent().set(&DataKey::Balance(to), &(balance + amount));
+        let supply: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalSupply, &(supply + amount));
+    }}
+
+    pub fn burn(env: Env, from: Address, amount: i128) {{
+        from.require_auth();
+        let balance: i128 = env.storage().persistent().get(&DataKey::Balance(from.clone())).unwrap_or(0);
+        if balance < amount {{ panic!("insufficient balance"); }}
+        env.storage().persistent().set(&DataKey::Balance(from), &(balance - amount));
+        let supply: i128 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalSupply, &(supply - amount));
+    }}
+
+    pub fn balance(env: Env, id: Address) -> i128 {{
+        env.storage().persistent().get(&DataKey::Balance(id)).unwrap_or(0)
+    }}
+
+    pub fn total_supply(env: Env) -> i128 {{
+        env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
+    }}
+}}
+
+#[cfg(test)]
+mod test {{
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn test_stablecoin_lifecycle() {{
+        let env = Env::default();
+        let id = env.register_contract(None, {pascal});
+        let client = {pascal}Client::new(&env, &id);
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin, &String::from_str(&env, "USDC"));
+        client.mint(&user, &1000);
+        assert_eq!(client.balance(&user), 1000);
+        assert_eq!(client.total_supply(), 1000);
+        client.burn(&user, &400);
+        assert_eq!(client.balance(&user), 600);
+        assert_eq!(client.total_supply(), 600);
+    }}
+}}
+"#, pascal = pascal)
+}
+
+fn escrow_template(name: &str) -> String {
+    let pascal = to_pascal(name);
+    format!(r#"#![no_std]
+use soroban_sdk::{{contract, contractimpl, contracttype, Address, Env}};
+
+#[derive(Clone, PartialEq)]
+#[contracttype]
+pub enum EscrowState {{
+    Pending,
+    Released,
+    Refunded,
+}}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Escrow {{
+    pub depositor: Address,
+    pub beneficiary: Address,
+    pub arbiter: Address,
+    pub amount: i128,
+    pub state: EscrowState,
+}}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {{
+    Escrow,
+}}
+
+#[contract]
+pub struct {pascal};
+
+#[contractimpl]
+impl {pascal} {{
+    pub fn deposit(env: Env, depositor: Address, beneficiary: Address, arbiter: Address, amount: i128) {{
+        depositor.require_auth();
+        if env.storage().instance().has(&DataKey::Escrow) {{
+            panic!("escrow already initialized");
+        }}
+        env.storage().instance().set(&DataKey::Escrow, &Escrow {{
+            depositor,
+            beneficiary,
+            arbiter,
+            amount,
+            state: EscrowState::Pending,
+        }});
+    }}
+
+    pub fn release(env: Env) {{
+        let mut escrow: Escrow = env.storage().instance().get(&DataKey::Escrow).unwrap();
+        escrow.arbiter.require_auth();
+        if escrow.state != EscrowState::Pending {{ panic!("escrow not pending"); }}
+        escrow.state = EscrowState::Released;
+        env.storage().instance().set(&DataKey::Escrow, &escrow);
+    }}
+
+    pub fn refund(env: Env) {{
+        let mut escrow: Escrow = env.storage().instance().get(&DataKey::Escrow).unwrap();
+        escrow.arbiter.require_auth();
+        if escrow.state != EscrowState::Pending {{ panic!("escrow not pending"); }}
+        escrow.state = EscrowState::Refunded;
+        env.storage().instance().set(&DataKey::Escrow, &escrow);
+    }}
+
+    pub fn state(env: Env) -> EscrowState {{
+        let escrow: Escrow = env.storage().instance().get(&DataKey::Escrow).unwrap();
+        escrow.state
+    }}
+}}
+
+#[cfg(test)]
+mod test {{
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn test_escrow_release() {{
+        let env = Env::default();
+        let id = env.register_contract(None, {pascal});
+        let client = {pascal}Client::new(&env, &id);
+        let depositor = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let arbiter = Address::generate(&env);
+        env.mock_all_auths();
+        client.deposit(&depositor, &beneficiary, &arbiter, &500);
+        client.release();
+        assert_eq!(client.state(), EscrowState::Released);
+    }}
+
+    #[test]
+    fn test_escrow_refund() {{
+        let env = Env::default();
+        let id = env.register_contract(None, {pascal});
+        let client = {pascal}Client::new(&env, &id);
+        let depositor = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let arbiter = Address::generate(&env);
+        env.mock_all_auths();
+        client.deposit(&depositor, &beneficiary, &arbiter, &500);
+        client.refund();
+        assert_eq!(client.state(), EscrowState::Refunded);
     }}
 }}
 "#, pascal = pascal)


### PR DESCRIPTION
Closes #112

## Changes
- Added `stablecoin` template: pegged stablecoin with `initialize`, `mint`, `burn`, `balance`, `total_supply` and a test module
- Added `escrow` template: three-party escrow with `deposit`, `release`, `refund`, `state` and two test cases (release + refund)
- Wired both into the `scaffold_contract` match in `new.rs`
- Updated README template list to include `stablecoin` and `escrow`
- Added **Built-in Templates** reference table to `QUICK_START_TEMPLATES.md`

## Testing
- Both templates include `#[cfg(test)]` modules covering the happy path
- Follows the same structure as existing `token` and `voting` templates

## Notes
- Stablecoin stores the pegged asset symbol; no oracle integration (out of scope for a scaffold)
- Escrow tracks amount as metadata; actual token transfer is left to the integrating dApp