### PR TITLE
feat: added --follow flag for contract monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +241,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -500,6 +515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +656,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1252,9 +1290,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1364,6 +1402,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1442,21 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -2098,6 +2163,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "criterion",
+ "ctrlc",
  "dialoguer",
  "dirs",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ chrono   = { version = "0.4", features = ["serde"] }
 rand     = "0.8"
 ed25519-dalek = "2.1"
 ureq       = { version = "=2.7.1", features = ["json"] }
+ctrlc      = "3.4"
 clap_complete  = "=4.4.10"
 dialoguer  = { version = "0.11", features = ["fuzzy-select", "password"] }
 aes-gcm = "0.10.3"

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1,6 +1,10 @@
-use crate::utils::{config, horizon, notifications, print as p, stream::SorobanEventStream};
+use crate::utils::{config, horizon, notifications, print as p, soroban, stream::SorobanEventStream};
 use anyhow::Result;
 use clap::Args;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 #[derive(Args)]
 pub struct MonitorArgs {
@@ -11,6 +15,10 @@ pub struct MonitorArgs {
     /// Comma-separated list of event names to filter (best-effort; matches topic strings)
     #[arg(long)]
     pub events: Option<String>,
+
+    /// Stream events continuously until Ctrl+C (contract mode)
+    #[arg(long)]
+    pub follow: bool,
 
     /// Wallet name from starforge config to monitor
     #[arg(long)]
@@ -41,7 +49,13 @@ pub fn handle(args: MonitorArgs) -> Result<()> {
     println!();
 
     match (&args.contract, &args.wallet) {
-        (Some(contract_id), None) => monitor_contract(contract_id, args.events.as_deref(), network, args.interval),
+        (Some(contract_id), None) => monitor_contract(
+            contract_id,
+            args.events.as_deref(),
+            network,
+            args.interval,
+            args.follow,
+        ),
         (None, Some(wallet_name)) => monitor_wallet(wallet_name, args.threshold, network, args.interval),
         _ => anyhow::bail!("Specify either --contract or --wallet (but not both)"),
     }
@@ -52,6 +66,7 @@ fn monitor_contract(
     events_filter: Option<&str>,
     network: &str,
     interval: u64,
+    follow: bool,
 ) -> Result<()> {
     config::validate_contract_id(contract_id)?;
 
@@ -62,42 +77,68 @@ fn monitor_contract(
             .collect()
     });
 
-    let rpc_url = match network {
-        "mainnet" => "https://mainnet.sorobanrpc.com",
-        "docker-testnet" => "http://localhost:8000/rpc",
-        _ => "https://soroban-testnet.stellar.org",
-    }
-    .to_string();
+    let rpc_url = soroban::rpc_url(network);
 
     notifications::info(&format!(
-        "Streaming contract events from {} (best-effort polling).",
+        "Streaming contract events from {}.",
         rpc_url
     ));
 
-    let mut stream = SorobanEventStream::new(rpc_url, contract_id.to_string()).with_poll_interval(interval);
-    loop {
-        let batch = stream.next_batch()?;
-        for event in batch {
-            let as_text = event.value.to_string();
-            if let Some(ref filters) = filter_set {
-                let mut matches = false;
-                for f in filters {
-                    if as_text.to_lowercase().contains(f) {
-                        matches = true;
-                        break;
-                    }
-                }
-                if !matches {
-                    continue;
-                }
-            }
-            notifications::success(&format!(
-                "Ledger {} event {}: {}",
-                event.ledger, event.id, as_text
-            ));
-        }
-        stream.sleep();
+    let should_run = Arc::new(AtomicBool::new(true));
+    {
+        let should_run = Arc::clone(&should_run);
+        let _ = ctrlc::set_handler(move || {
+            should_run.store(false, Ordering::SeqCst);
+        });
     }
+
+    let mut stream =
+        SorobanEventStream::new(rpc_url, contract_id.to_string()).with_poll_interval(interval);
+
+    let mut printed_any = false;
+    while should_run.load(Ordering::SeqCst) {
+        match stream.next_batch() {
+            Ok(batch) => {
+                for event in batch {
+                    let as_text = event.value.to_string();
+                    if let Some(ref filters) = filter_set {
+                        let mut matches = false;
+                        for f in filters {
+                            if as_text.to_lowercase().contains(f) {
+                                matches = true;
+                                break;
+                            }
+                        }
+                        if !matches {
+                            continue;
+                        }
+                    }
+                    printed_any = true;
+                    notifications::success(&format!(
+                        "Ledger {} event {}: {}",
+                        event.ledger, event.id, as_text
+                    ));
+                }
+
+                if !follow {
+                    break;
+                }
+                stream.sleep();
+            }
+            Err(err) => {
+                if !follow && !printed_any {
+                    return Err(err);
+                }
+                notifications::warn(&format!(
+                    "Event stream error: {}. Reconnecting with backoff…",
+                    err
+                ));
+                stream.sleep_backoff();
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn monitor_wallet(

--- a/src/utils/soroban.rs
+++ b/src/utils/soroban.rs
@@ -183,6 +183,10 @@ fn get_rpc_url(network: &str) -> String {
     }
 }
 
+pub fn rpc_url(network: &str) -> String {
+    get_rpc_url(network)
+}
+
 fn rpc_request_with_url<T>(rpc_url: &str, request: SorobanRpcRequest) -> Result<T>
 where
     T: DeserializeOwned,

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use rand::Rng;
 use serde::Deserialize;
 use std::thread;
 use std::time::Duration;
@@ -9,6 +10,7 @@ pub struct SorobanEventStream {
     contract_id: String,
     cursor: Option<String>,
     poll_interval: Duration,
+    backoff: Backoff,
 }
 
 impl SorobanEventStream {
@@ -18,6 +20,7 @@ impl SorobanEventStream {
             contract_id,
             cursor: None,
             poll_interval: Duration::from_secs(2),
+            backoff: Backoff::default(),
         }
     }
 
@@ -65,11 +68,16 @@ impl SorobanEventStream {
             .ok_or_else(|| anyhow::anyhow!("Soroban RPC getEvents returned no result"))?;
 
         self.cursor = result.cursor;
+        self.backoff.reset();
         Ok(result.events)
     }
 
     pub fn sleep(&self) {
         thread::sleep(self.poll_interval);
+    }
+
+    pub fn sleep_backoff(&mut self) {
+        thread::sleep(self.backoff.next_delay());
     }
 }
 
@@ -96,5 +104,45 @@ pub struct SorobanEvent {
     #[allow(dead_code)]
     pub topic: Vec<String>,
     pub value: serde_json::Value,
+}
+
+#[derive(Debug, Clone)]
+struct Backoff {
+    attempt: u32,
+    base: Duration,
+    max: Duration,
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self {
+            attempt: 0,
+            base: Duration::from_millis(250),
+            max: Duration::from_secs(15),
+        }
+    }
+}
+
+impl Backoff {
+    fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        // Exponential backoff with jitter. Attempt is capped to keep duration bounded.
+        let capped = self.attempt.min(16);
+        self.attempt = self.attempt.saturating_add(1);
+
+        let pow2_ms = self
+            .base
+            .as_millis()
+            .saturating_mul(1u128.saturating_shl(capped));
+        let raw_ms = pow2_ms.min(self.max.as_millis());
+
+        let jitter = rand::thread_rng().gen_range(0..=250u128);
+        let ms = (raw_ms + jitter).min(self.max.as_millis());
+
+        Duration::from_millis(ms as u64)
+    }
 }
 

--- a/src/utils/template.rs
+++ b/src/utils/template.rs
@@ -1,0 +1,2 @@
+pub use crate::utils::templates::*;
+

--- a/src/utils/templates.rs
+++ b/src/utils/templates.rs
@@ -3,9 +3,6 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TemplateRegistry {
-    pub version: String,
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TemplateRegistry {
     #[serde(default)]


### PR DESCRIPTION
# Summary

Added support for continuous Soroban event streaming via:

```bash
starforge monitor --contract <CID> --follow
```

The monitor can now run continuously until interrupted with `Ctrl+C`, making it suitable for real-time contract observation.

To improve reliability, the event stream now automatically reconnects on Soroban RPC failures using exponential backoff with jitter, preventing transient network issues from terminating monitoring sessions.

Additionally, Soroban RPC endpoint selection has been centralized behind a shared helper to eliminate duplicated network mapping logic across the codebase.

## Changes

### `src/commands/monitor.rs`

#### New `--follow` Flag

Added support for:

```bash
starforge monitor --contract <CID> --follow
```

Closes: #123 