### PR TITLE
Add logging redaction functions and security audit tests

### DIFF
--- a/SECURITY_LOGGING_AUDIT.md
+++ b/SECURITY_LOGGING_AUDIT.md
@@ -1,0 +1,33 @@
+# Security Logging Audit
+
+This audit ensures that secret material is never emitted at info level in the command handlers and logging helpers.
+
+## Sensitive data categories
+
+- Secret keys
+- Passphrases
+- Signed XDR envelopes or transactions
+
+## Grep-based checks
+
+Use these commands from the repository root to validate the audit:
+
+```bash
+grep -R --line-number -E 'p::info\(|tracing::info!|info!\(' src/commands/wallet.rs src/commands/deploy.rs
+grep -R --line-number -E 'Secret Key|passphrase|transaction_xdr|signed_xdr|XDR' src/commands/wallet.rs src/commands/deploy.rs
+```
+
+## Implementation notes
+
+- `src/utils/logging.rs` now exposes helpers for redacting sensitive log data:
+  - `redact_public_key(public_key, level)` hides public keys in info-level logs but preserves them in debug and trace logs.
+  - `redact_secret_value(_)` always returns `"[REDACTED]"` for secret keys and passphrases.
+  - `redact_signed_xdr(_)` always returns `"[REDACTED]"` for signed XDR payloads.
+
+- `tests/security_logging_audit.rs` contains a grep-based regression test that scans `src/commands/wallet.rs` and `src/commands/deploy.rs` for suspicious info-level patterns.
+
+## Running the audit
+
+```bash
+cargo test --test security_logging_audit
+```

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -123,6 +123,39 @@ pub fn init(config: LogConfig) -> Result<()> {
     Ok(())
 }
 
+/// Redact a public Stellar key unless the current log level is debug or trace.
+///
+/// Public keys are safe to display to users, but log streams should avoid
+/// including raw account IDs in info-level logs unless the log level is explicitly
+/// opted into debug.
+pub fn redact_public_key(public_key: &str, level: Level) -> String {
+    if matches!(level, Level::DEBUG | Level::TRACE) {
+        public_key.to_string()
+    } else if public_key.len() > 8 {
+        let prefix = &public_key[..4];
+        let suffix = &public_key[public_key.len().saturating_sub(4)..];
+        format!("{}...{}", prefix, suffix)
+    } else {
+        "[REDACTED]".to_string()
+    }
+}
+
+/// Always redact secret values when they are written to logs.
+///
+/// Secret keys and passphrases should never appear in info-level or debug-level
+/// logs.
+pub fn redact_secret_value(_value: &str) -> &'static str {
+    "[REDACTED]"
+}
+
+/// Always redact signed XDR payloads when they are written to logs.
+///
+/// XDR envelopes containing signatures are secret and must not be emitted at
+/// info level.
+pub fn redact_signed_xdr(_xdr: &str) -> &'static str {
+    "[REDACTED]"
+}
+
 /// Build a `LogConfig` from CLI flags / environment.
 ///
 /// - `--log-format json` → `LogFormat::Json`
@@ -138,5 +171,39 @@ pub fn config_from_env(format: Option<&str>, log_dir: Option<std::path::PathBuf>
         format,
         log_dir,
         ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::Level;
+
+    #[test]
+    fn redact_public_key_hides_value_at_info_level() {
+        let key = "GDRXMZDQW34QHX6F5U6FFWJZZZDQ4KYWJO65HS4CUT62X7Y7RXYWXE4T";
+        let redacted = redact_public_key(key, Level::INFO);
+
+        assert!(redacted.starts_with("GDRX"));
+        assert!(redacted.ends_with("4T"));
+        assert!(redacted.contains("..."));
+        assert_ne!(redacted, key);
+    }
+
+    #[test]
+    fn redact_public_key_returns_full_value_at_debug_level() {
+        let key = "GDRXMZDQW34QHX6F5U6FFWJZZZDQ4KYWJO65HS4CUT62X7Y7RXYWXE4T";
+        assert_eq!(redact_public_key(key, Level::DEBUG), key);
+        assert_eq!(redact_public_key(key, Level::TRACE), key);
+    }
+
+    #[test]
+    fn redact_secret_value_always_redacts() {
+        assert_eq!(redact_secret_value("super-secret"), "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_signed_xdr_always_redacts() {
+        assert_eq!(redact_signed_xdr("signed-xdr-payload"), "[REDACTED]");
     }
 }

--- a/tests/security_logging_audit.rs
+++ b/tests/security_logging_audit.rs
@@ -1,0 +1,33 @@
+use std::fs;
+
+const FILES_TO_AUDIT: &[&str] = &["src/commands/wallet.rs", "src/commands/deploy.rs"];
+
+#[test]
+fn no_sensitive_patterns_are_emitted_at_info_level() {
+    let patterns = [
+        ("p::info(", "Secret Key"),
+        ("p::info(", "secret_key"),
+        ("p::info(", "plain_sk"),
+        ("p::info(", "transaction_xdr"),
+        ("p::info(", "signed_xdr"),
+        ("p::info(", "XDR"),
+    ];
+
+    for path in FILES_TO_AUDIT {
+        let contents = fs::read_to_string(path).expect(&format!("Failed to read {}", path));
+        for (prefix, sensitive) in patterns {
+            for (index, line) in contents.lines().enumerate() {
+                if line.contains(prefix) && line.contains(sensitive) {
+                    panic!(
+                        "Sensitive pattern found in {}:{}:\n  {}\n  contains both '{}' and '{}'",
+                        path,
+                        index + 1,
+                        line.trim(),
+                        prefix,
+                        sensitive
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #134

---

- Implement `redact_public_key`, `redact_secret_value`, and `redact_signed_xdr` to ensure sensitive data is not logged at info level.
- Create a security logging audit to validate that sensitive patterns are not emitted in command handlers.
- Add tests to verify redaction functionality and audit checks for sensitive data in logs.