### PR TITLE
feat: implement Soroban RPC utilities and add request/response test

### DIFF
--- a/src/utils/soroban.rs
+++ b/src/utils/soroban.rs
@@ -581,6 +581,129 @@ fn extract_rpc_error_message(error: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn read_fixture(filename: &str) -> String {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("soroban_rpc")
+            .join(filename);
+        fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to read fixture {}: {}", path.display(), e))
+    }
+
+    #[test]
+    fn test_parse_simulate_success() {
+        let fixture = read_fixture("simulate_success.json");
+        let response: SorobanRpcResponse<serde_json::Value> =
+            serde_json::from_str(&fixture).expect("failed to deserialize simulate_success.json");
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("missing result in response");
+
+        let return_value = decode_return_value(&result).unwrap();
+        assert_eq!(return_value, "success_value");
+
+        let fee = extract_fee(&result).unwrap();
+        assert_eq!(fee, 150000);
+
+        let events = extract_events(&result).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(events[0].contains("test_key"));
+        assert!(events[1].contains("test_key2"));
+
+        let errors = extract_simulation_errors(&result);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_parse_simulate_error_top_level() {
+        let fixture = read_fixture("simulate_error_top_level.json");
+        let response: SorobanRpcResponse<serde_json::Value> =
+            serde_json::from_str(&fixture).expect("failed to deserialize simulate_error_top_level.json");
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("missing result in response");
+
+        let errors = extract_simulation_errors(&result);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0], "\"Simulation failed due to budget exceeded\"");
+    }
+
+    #[test]
+    fn test_parse_simulate_error_in_results() {
+        let fixture = read_fixture("simulate_error_in_results.json");
+        let response: SorobanRpcResponse<serde_json::Value> =
+            serde_json::from_str(&fixture).expect("failed to deserialize simulate_error_in_results.json");
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("missing result in response");
+
+        let errors = extract_simulation_errors(&result);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0], "\"Contract call panicked\"");
+    }
+
+    #[test]
+    fn test_parse_get_ledger_entries_success() {
+        let fixture = read_fixture("get_ledger_entries_success.json");
+        let response: SorobanRpcResponse<GetLedgerEntriesResult> =
+            serde_json::from_str(&fixture).expect("failed to deserialize get_ledger_entries_success.json");
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("missing result in response");
+
+        let inspect_res = parse_contract_inspect_result(
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGHI",
+            "testnet",
+            result,
+        )
+        .unwrap();
+
+        assert_eq!(inspect_res.contract_id, "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGHI");
+        assert_eq!(inspect_res.executable, "Wasm");
+        assert_eq!(inspect_res.wasm_hash, Some("mock_wasm_hash_placeholder".to_string()));
+        assert_eq!(inspect_res.storage_durability, "Persistent");
+        assert_eq!(inspect_res.latest_ledger, 42000);
+        assert_eq!(inspect_res.last_modified_ledger_seq, Some(41990));
+        assert_eq!(inspect_res.live_until_ledger_seq, Some(45000));
+        assert!(inspect_res.instance_storage.is_empty());
+    }
+
+    #[test]
+    fn test_parse_get_ledger_entries_empty() {
+        let fixture = read_fixture("get_ledger_entries_empty.json");
+        let response: SorobanRpcResponse<GetLedgerEntriesResult> =
+            serde_json::from_str(&fixture).expect("failed to deserialize get_ledger_entries_empty.json");
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("missing result in response");
+
+        let err = parse_contract_inspect_result(
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGHI",
+            "testnet",
+            result,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Contract 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABGHI' was not found on testnet."
+        );
+    }
+
+    #[test]
+    fn test_parse_rpc_error() {
+        let fixture = read_fixture("rpc_error.json");
+        let response: SorobanRpcResponse<serde_json::Value> =
+            serde_json::from_str(&fixture).expect("failed to deserialize rpc_error.json");
+
+        let error = response.error.expect("missing error in response");
+        let message = extract_rpc_error_message(&error);
+        assert_eq!(message, "Invalid request");
+    }
 
     #[test]
     fn builds_contract_instance_ledger_key() {

--- a/tests/fixtures/soroban_rpc/get_ledger_entries_empty.json
+++ b/tests/fixtures/soroban_rpc/get_ledger_entries_empty.json
@@ -1,0 +1,8 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "latestLedger": 42000,
+    "entries": []
+  }
+}

--- a/tests/fixtures/soroban_rpc/get_ledger_entries_success.json
+++ b/tests/fixtures/soroban_rpc/get_ledger_entries_success.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "latestLedger": 42000,
+    "entries": [
+      {
+        "xdr": "AAAAAAAAADAAAAABAAAAAQAAAA...",
+        "lastModifiedLedgerSeq": 41990,
+        "liveUntilLedgerSeq": 45000
+      }
+    ]
+  }
+}

--- a/tests/fixtures/soroban_rpc/rpc_error.json
+++ b/tests/fixtures/soroban_rpc/rpc_error.json
@@ -1,0 +1,8 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32600,
+    "message": "Invalid request"
+  }
+}

--- a/tests/fixtures/soroban_rpc/simulate_error_in_results.json
+++ b/tests/fixtures/soroban_rpc/simulate_error_in_results.json
@@ -1,0 +1,11 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "results": [
+      {
+        "error": "Contract call panicked"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/soroban_rpc/simulate_error_top_level.json
+++ b/tests/fixtures/soroban_rpc/simulate_error_top_level.json
@@ -1,0 +1,7 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "error": "Simulation failed due to budget exceeded"
+  }
+}

--- a/tests/fixtures/soroban_rpc/simulate_success.json
+++ b/tests/fixtures/soroban_rpc/simulate_success.json
@@ -1,0 +1,22 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "latestLedger": 12345,
+    "cost": {
+      "cpuInsns": 150000,
+      "memBytes": 2048
+    },
+    "results": [
+      {
+        "xdr": "AAAABQ==",
+        "auth": []
+      }
+    ],
+    "events": [
+      "AAAAEAAAAAEAAAABAAAADgAAAAh0ZXN0X2tleQAAAA4AAAAJZ29vZF92YWw=",
+      "AAAAEAAAAAEAAAABAAAADgAAAAh0ZXN0X2tleTIAAAA4AAAACWJ1ZF92YWwy"
+    ],
+    "returnValue": "success_value"
+  }
+}


### PR DESCRIPTION
Closes #128

---

feat: implement Soroban RPC utilities and add request/response test fixtures