### PR TITLE
feat(monitor): advanced event filters and balance-alert watchman

### DIFF
--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -202,6 +202,7 @@ fn monitor_contract(
 fn monitor_wallet(
     wallet_name: &str,
     threshold: Option<f64>,
+    balance_alert: Option<f64>,
     network: &str,
     interval: u64,
 ) -> Result<()> {
@@ -213,8 +214,20 @@ fn monitor_wallet(
         .ok_or_else(|| anyhow::anyhow!("Wallet '{}' not found", wallet_name))?;
 
     let threshold = threshold.unwrap_or(0.0);
-    if threshold <= 0.0 {
-        notifications::warn("No --threshold provided; will print balance changes only.");
+    if threshold <= 0.0 && balance_alert.is_none() {
+        notifications::warn(
+            "No --threshold or --balance-alert provided; will print balance changes only.",
+        );
+    }
+
+    if let Some(alert_level) = balance_alert {
+        if alert_level <= 0.0 {
+            anyhow::bail!("--balance-alert must be greater than zero");
+        }
+        notifications::info(&format!(
+            "Watchman enabled: alert when balance drops below {:.7} XLM.",
+            alert_level
+        ));
     }
 
     notifications::info(&format!(
@@ -223,7 +236,17 @@ fn monitor_wallet(
     ));
 
     let mut last_balance: Option<f64> = None;
-    loop {
+    let mut low_balance_alerted = false;
+
+    let running = Arc::new(AtomicBool::new(true));
+    {
+        let running = Arc::clone(&running);
+        ctrlc::set_handler(move || {
+            running.store(false, Ordering::SeqCst);
+        })?;
+    }
+
+    while running.load(Ordering::SeqCst) {
         let account = horizon::fetch_account(&wallet.public_key, network)?;
         let native = account
             .balances
@@ -249,4 +272,6 @@ fn monitor_wallet(
 
         std::thread::sleep(std::time::Duration::from_secs(interval.max(1)));
     }
+
+    Ok(())
 }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -270,6 +270,20 @@ fn monitor_wallet(
             ));
         }
 
+        if let Some(alert_level) = balance_alert {
+            if native < alert_level {
+                if !low_balance_alerted {
+                    notifications::alert(&format!(
+                        "Balance {:.7} XLM dropped below watchman threshold {:.7} XLM",
+                        native, alert_level
+                    ));
+                    low_balance_alerted = true;
+                }
+            } else {
+                low_balance_alerted = false;
+            }
+        }
+
         std::thread::sleep(std::time::Duration::from_secs(interval.max(1)));
     }
 

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -20,6 +20,18 @@ pub struct MonitorArgs {
     #[arg(long)]
     pub follow: bool,
 
+    /// Soroban event type filter (contract, system, diagnostic)
+    #[arg(long = "type")]
+    pub event_type: Option<String>,
+
+    /// Topic filter: comma-separated segment matchers (* wildcards supported)
+    #[arg(long)]
+    pub topic: Option<String>,
+
+    /// Match emitted event value (substring match on JSON payload)
+    #[arg(long)]
+    pub value: Option<String>,
+
     /// Wallet name from starforge config to monitor
     #[arg(long)]
     pub wallet: Option<String>,
@@ -27,6 +39,10 @@ pub struct MonitorArgs {
     /// Threshold amount in XLM to trigger a notification (wallet mode)
     #[arg(long)]
     pub threshold: Option<f64>,
+
+    /// Alert when wallet XLM balance drops below this amount (watchman)
+    #[arg(long)]
+    pub balance_alert: Option<f64>,
 
     /// Network to use (overrides config)
     #[arg(long)]

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1,4 +1,7 @@
-use crate::utils::{config, horizon, notifications, print as p, soroban, stream::SorobanEventStream};
+use crate::utils::{
+    config, horizon, notifications, print as p, soroban,
+    stream::{EventStreamFilters, SorobanEventStream},
+};
 use anyhow::Result;
 use clap::Args;
 use std::sync::{
@@ -65,12 +68,23 @@ pub fn handle(args: MonitorArgs) -> Result<()> {
     println!();
 
     match (&args.contract, &args.wallet) {
-        (Some(contract_id), None) => {
-            monitor_contract(contract_id, args.events.as_deref(), network, args.interval)
-        }
-        (None, Some(wallet_name)) => {
-            monitor_wallet(wallet_name, args.threshold, network, args.interval)
-        }
+        (Some(contract_id), None) => monitor_contract(
+            contract_id,
+            args.events.as_deref(),
+            args.event_type.as_deref(),
+            args.topic.as_deref(),
+            args.value.as_deref(),
+            network,
+            args.interval,
+            args.follow,
+        ),
+        (None, Some(wallet_name)) => monitor_wallet(
+            wallet_name,
+            args.threshold,
+            args.balance_alert,
+            network,
+            args.interval,
+        ),
         _ => anyhow::bail!("Specify either --contract or --wallet (but not both)"),
     }
 }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -92,18 +92,45 @@ pub fn handle(args: MonitorArgs) -> Result<()> {
 fn monitor_contract(
     contract_id: &str,
     events_filter: Option<&str>,
+    event_type: Option<&str>,
+    topic: Option<&str>,
+    value: Option<&str>,
     network: &str,
     interval: u64,
     follow: bool,
 ) -> Result<()> {
     config::validate_contract_id(contract_id)?;
 
-    let filter_set: Option<Vec<String>> = events_filter.map(|s| {
+    let legacy_filter_set: Option<Vec<String>> = events_filter.map(|s| {
         s.split(',')
             .map(|x| x.trim().to_lowercase())
             .filter(|x| !x.is_empty())
             .collect()
     });
+
+    let mut stream_filters = EventStreamFilters::default();
+    if let Some(t) = event_type {
+        let normalized = t.trim().to_lowercase();
+        if !normalized.is_empty() {
+            stream_filters.event_type = Some(normalized);
+        }
+    }
+    if let Some(topic_filter) = topic {
+        let segments: Vec<String> = topic_filter
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !segments.is_empty() {
+            stream_filters.topic_segments = Some(segments);
+        }
+    }
+    if let Some(value_match) = value {
+        let trimmed = value_match.trim();
+        if !trimmed.is_empty() {
+            stream_filters.value_match = Some(trimmed.to_string());
+        }
+    }
 
     let rpc_url = soroban::rpc_url(network);
 
@@ -112,27 +139,46 @@ fn monitor_contract(
         rpc_url
     ));
 
-    let mut stream =
-        SorobanEventStream::new(rpc_url, contract_id.to_string()).with_poll_interval(interval);
-    loop {
-        let batch = stream.next_batch()?;
-        for event in batch {
-            let as_text = event.value.to_string();
-            if let Some(ref filters) = filter_set {
-                let mut matches = false;
-                for f in filters {
-                    if as_text.to_lowercase().contains(f) {
-                        matches = true;
-                        break;
+    let running = Arc::new(AtomicBool::new(true));
+    {
+        let running = Arc::clone(&running);
+        ctrlc::set_handler(move || {
+            running.store(false, Ordering::SeqCst);
+        })?;
+    }
+
+    let mut stream = SorobanEventStream::new(rpc_url, contract_id.to_string())
+        .with_poll_interval(interval)
+        .with_filters(stream_filters);
+
+    let mut printed_any = false;
+
+    while running.load(Ordering::SeqCst) {
+        match stream.next_batch() {
+            Ok(batch) => {
+                for event in batch {
+                    let as_text = event.value.to_string();
+                    let topic_text = event.topic.join(",");
+                    let matches_legacy = legacy_filter_set.as_ref().is_none_or(|filters| {
+                        filters.iter().any(|f| {
+                            as_text.to_lowercase().contains(f)
+                                || topic_text.to_lowercase().contains(f)
+                        })
+                    });
+
+                    if matches_legacy {
+                        printed_any = true;
+                        notifications::success(&format!(
+                            "Ledger {} event {}: {}",
+                            event.ledger, event.id, as_text
+                        ));
                     }
-                    printed_any = true;
-                    notifications::success(&format!(
-                        "Ledger {} event {}: {}",
-                        event.ledger, event.id, as_text
-                    ));
                 }
 
                 if !follow {
+                    if !printed_any {
+                        notifications::warn("No matching events in the latest batch.");
+                    }
                     break;
                 }
                 stream.sleep();

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -1,4 +1,5 @@
 use colored::*;
+use std::process::Command;
 
 pub fn info(message: &str) {
     println!("  {} {}", "•".bright_blue(), message);
@@ -10,4 +11,36 @@ pub fn success(message: &str) {
 
 pub fn warn(message: &str) {
     eprintln!("  {} {}", "!".yellow().bold(), message);
+}
+
+/// Terminal alert with optional OS notification (watchman).
+pub fn alert(message: &str) {
+    eprintln!(
+        "\n  {} {}\n",
+        "⚠ ALERT:".red().bold(),
+        message.bright_white().bold()
+    );
+    print!("\x07");
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+    try_system_notification(message);
+}
+
+fn try_system_notification(message: &str) {
+    let escaped = message.replace('\\', "\\\\").replace('"', "\\\"");
+
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            "display notification \"{}\" with title \"StarForge\"",
+            escaped
+        );
+        let _ = Command::new("osascript").args(["-e", &script]).status();
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = Command::new("notify-send")
+            .args(["StarForge", message])
+            .status();
+    }
 }

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use rand::Rng;
 use serde::Deserialize;
 use std::thread;
 use std::time::Duration;
@@ -11,6 +10,36 @@ pub struct SorobanEventStream {
     cursor: Option<String>,
     poll_interval: Duration,
     backoff: Backoff,
+}
+
+#[derive(Debug, Clone)]
+struct Backoff {
+    attempt: u32,
+    base_ms: u64,
+    max_ms: u64,
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self {
+            attempt: 0,
+            base_ms: 500,
+            max_ms: 30_000,
+        }
+    }
+}
+
+impl Backoff {
+    fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        let exp = self.attempt.min(6);
+        self.attempt = self.attempt.saturating_add(1);
+        let ms = (self.base_ms.saturating_mul(1_u64 << exp)).min(self.max_ms);
+        Duration::from_millis(ms)
+    }
 }
 
 impl SorobanEventStream {
@@ -101,7 +130,6 @@ pub struct SorobanEvent {
     pub ledger: u32,
     pub id: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub topic: Vec<String>,
     pub value: serde_json::Value,
 }

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -1,7 +1,17 @@
 use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use serde::Deserialize;
+use stellar_xdr::curr::{Limited, Limits, ScSymbol, ScVal, WriteXdr};
 use std::thread;
 use std::time::Duration;
+
+/// RPC and client-side filters for Soroban `getEvents`.
+#[derive(Debug, Clone, Default)]
+pub struct EventStreamFilters {
+    pub event_type: Option<String>,
+    pub topic_segments: Option<Vec<String>>,
+    pub value_match: Option<String>,
+}
 
 #[derive(Debug, Clone)]
 pub struct SorobanEventStream {
@@ -10,6 +20,7 @@ pub struct SorobanEventStream {
     cursor: Option<String>,
     poll_interval: Duration,
     backoff: Backoff,
+    filters: EventStreamFilters,
 }
 
 #[derive(Debug, Clone)]
@@ -50,6 +61,7 @@ impl SorobanEventStream {
             cursor: None,
             poll_interval: Duration::from_secs(2),
             backoff: Backoff::default(),
+            filters: EventStreamFilters::default(),
         }
     }
 
@@ -58,16 +70,34 @@ impl SorobanEventStream {
         self
     }
 
+    pub fn with_filters(mut self, filters: EventStreamFilters) -> Self {
+        self.filters = filters;
+        self
+    }
+
+    pub fn with_event_type(mut self, event_type: impl Into<String>) -> Self {
+        self.filters.event_type = Some(event_type.into());
+        self
+    }
+
+    pub fn with_topic_segments(mut self, segments: Vec<String>) -> Self {
+        self.filters.topic_segments = Some(segments);
+        self
+    }
+
+    pub fn with_value_match(mut self, pattern: impl Into<String>) -> Self {
+        self.filters.value_match = Some(pattern.into());
+        self
+    }
+
     pub fn next_batch(&mut self) -> Result<Vec<SorobanEvent>> {
+        let filter = self.build_rpc_filter();
         let request = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "getEvents",
             "params": {
-                "filters": [{
-                    "type": "contract",
-                    "contractIds": [self.contract_id],
-                }],
+                "filters": [filter],
                 "pagination": {
                     "cursor": self.cursor,
                     "limit": 10
@@ -98,7 +128,14 @@ impl SorobanEventStream {
 
         self.cursor = result.cursor;
         self.backoff.reset();
-        Ok(result.events)
+
+        let events = result
+            .events
+            .into_iter()
+            .filter(|event| event_matches_value(event, &self.filters))
+            .collect();
+
+        Ok(events)
     }
 
     pub fn sleep(&self) {
@@ -108,6 +145,73 @@ impl SorobanEventStream {
     pub fn sleep_backoff(&mut self) {
         thread::sleep(self.backoff.next_delay());
     }
+
+    fn build_rpc_filter(&self) -> serde_json::Value {
+        let event_type = self
+            .filters
+            .event_type
+            .as_deref()
+            .unwrap_or("contract");
+
+        let mut filter = serde_json::json!({
+            "type": event_type,
+            "contractIds": [self.contract_id],
+        });
+
+        if let Some(ref segments) = self.filters.topic_segments {
+            let encoded: Result<Vec<String>> =
+                segments.iter().map(|s| encode_topic_segment(s)).collect();
+            if let Ok(topic_row) = encoded {
+                if !topic_row.is_empty() {
+                    filter["topics"] = serde_json::json!([topic_row]);
+                }
+            }
+        }
+
+        filter
+    }
+}
+
+fn event_matches_value(event: &SorobanEvent, filters: &EventStreamFilters) -> bool {
+    let Some(ref pattern) = filters.value_match else {
+        return true;
+    };
+    if pattern.is_empty() {
+        return true;
+    }
+    let haystack = event.value.to_string().to_lowercase();
+    haystack.contains(&pattern.to_lowercase())
+}
+
+fn encode_topic_segment(segment: &str) -> Result<String> {
+    let trimmed = segment.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("topic segment cannot be empty");
+    }
+    if trimmed == "*" || trimmed == "**" {
+        return Ok(trimmed.to_string());
+    }
+    if looks_like_base64(trimmed) {
+        return Ok(trimmed.to_string());
+    }
+
+    let symbol = ScSymbol(
+        trimmed
+            .as_bytes()
+            .try_into()
+            .with_context(|| format!("invalid topic symbol '{}'", trimmed))?,
+    );
+    let scval = ScVal::Symbol(symbol);
+    let mut bytes = Vec::new();
+    scval.write_xdr(&mut Limited::new(&mut bytes, Limits::none()))?;
+    Ok(BASE64.encode(bytes))
+}
+
+fn looks_like_base64(value: &str) -> bool {
+    value.len() >= 8
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

- Add Soroban `getEvents` filtering in `stream.rs` with `--type`, `--topic`, and `--value` flags on `starforge monitor --contract`, including RPC topic encoding and client-side value matching.
- Restore the contract monitor loop with reconnect backoff and `--follow` support.
- Add a wallet watchman via `--balance-alert` that alerts the terminal and OS when XLM balance drops below the configured threshold.

## Verification

- Confirmed `src/utils/stream.rs`, `src/commands/monitor.rs`, and `src/utils/notifications.rs` compile with `cargo check` (other upstream files on `master` still have unrelated errors).
- Reviewed commit history: all commits authored and committed as `auraroom <auraroom001@gmail.com>`.
- Tests not run (per task instructions).

Closes #169
Closes #175

Made with [Cursor](https://cursor.com)