### PR TITLE
ci: cross-platform release matrix (Linux x86_64, macOS arm64, Windows, Linux aarch64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,24 +10,85 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.archive_name }}.${{ matrix.archive_ext }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64 — native
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive_name: starforge-linux-x86_64
+            archive_ext: tar.gz
+
+          # macOS ARM64 — native on macos-latest (M1 runner)
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            archive_name: starforge-macos-aarch64
+            archive_ext: tar.gz
+
+          # Windows x86_64 — native
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive_name: starforge-windows-x86_64
+            archive_ext: zip
+
+          # Linux ARM64 — cross-compiled using `cross`
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            archive_name: starforge-linux-aarch64
+            archive_ext: tar.gz
+
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      # Only runs for the aarch64-unknown-linux-gnu matrix entry
+      - name: Install aarch64 Linux cross-linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      # Tells cargo which linker to use when targeting aarch64 Linux
+      - name: Configure cargo linker for aarch64 Linux
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml << 'EOF'
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+          EOF
+
       - name: Build
-        run: cargo build --release --locked
-      - name: Package binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      # Linux and macOS produce .tar.gz
+      - name: Package binary (Linux / macOS)
+        if: runner.os != 'Windows'
         run: |
           mkdir -p dist
-          cp target/release/starforge dist/starforge
-          tar -czf dist/starforge-linux-x86_64.tar.gz -C dist starforge
+          tar -czf dist/${{ matrix.archive_name }}.${{ matrix.archive_ext }} \
+            -C target/${{ matrix.target }}/release starforge
+
+      # Windows produces .zip — uses PowerShell
+      - name: Package binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist
+          Compress-Archive -Path "target\${{ matrix.target }}\release\starforge.exe" -DestinationPath "dist\${{ matrix.archive_name }}.${{ matrix.archive_ext }}"
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: starforge-linux-x86_64
-          path: dist/starforge-linux-x86_64.tar.gz
+          name: ${{ matrix.archive_name }}
+          path: dist/${{ matrix.archive_name }}.${{ matrix.archive_ext }}
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/starforge-linux-x86_64.tar.gz
-
+          files: dist/${{ matrix.archive_name }}.${{ matrix.archive_ext }}


### PR DESCRIPTION
## Summary
Resolves #130. Replaces the single Linux-only build job with a 4-target
matrix that builds and publishes release artifacts for all platforms
specified in the acceptance criteria.

## Changes
- `.github/workflows/release.yml` — only file modified

## Build Matrix

| Runner | Rust Target | Artifact |
|---|---|---|
| ubuntu-latest | x86_64-unknown-linux-gnu | starforge-linux-x86_64.tar.gz |
| macos-latest | aarch64-apple-darwin | starforge-macos-aarch64.tar.gz |
| windows-latest | x86_64-pc-windows-msvc | starforge-windows-x86_64.zip |
| ubuntu-latest | aarch64-unknown-linux-gnu | starforge-linux-aarch64.tar.gz |

## Implementation Notes
- `fail-fast: false` so all 4 jobs run to completion independently
- aarch64 Linux uses `gcc-aarch64-linux-gnu` (apt) as cross-linker — no Docker required
- macOS target is `aarch64-apple-darwin` since `macos-latest` is an M1 runner
- Windows packaging uses PowerShell `Compress-Archive` for `.zip`
- Existing trigger (`push: tags: v*`) and permissions unchanged