### PR TITLE
fix: handle custom network fields and URL validation consistently

### DIFF
--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -132,7 +132,7 @@ fn monitor_contract(
         }
     }
 
-    let rpc_url = soroban::rpc_url(network);
+    let rpc_url = soroban::rpc_url(network)?;
 
     notifications::info(&format!(
         "Streaming contract events from {}.",

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -24,6 +24,9 @@ pub enum NetworkCommands {
         /// Optional network faucet / Friendbot URL
         #[arg(long)]
         friendbot_url: Option<String>,
+        /// Optional network passphrase for transaction signing (defaults to testnet passphrase)
+        #[arg(long)]
+        passphrase: Option<String>,
     },
     /// Test connectivity to a network
     Test {
@@ -37,14 +40,13 @@ pub fn handle(cmd: NetworkCommands) -> Result<()> {
     match cmd {
         NetworkCommands::Show => show(),
         NetworkCommands::Switch { network } => switch(network),
-        NetworkCommands::Add { name, horizon_url, soroban_rpc_url, friendbot_url } =>
-            add_network(name, horizon_url, soroban_rpc_url, friendbot_url),
         NetworkCommands::Add {
             name,
             horizon_url,
             soroban_rpc_url,
             friendbot_url,
-        } => add_network(name, horizon_url, soroban_rpc_url, friendbot_url),
+            passphrase,
+        } => add_network(name, horizon_url, soroban_rpc_url, friendbot_url, passphrase),
         NetworkCommands::Test { network } => test_network(network),
     }
 }
@@ -75,13 +77,8 @@ fn show() -> Result<()> {
 fn switch(target: String) -> Result<()> {
     let mut cfg = config::load()?;
 
-    // Validate network exists
-    if !cfg.networks.contains_key(&target) {
-        anyhow::bail!(
-            "Network '{}' not found. Use 'starforge network add' to create it.",
-            target
-        );
-    }
+    // Validate network exists (accepts built-ins + custom networks)
+    config::validate_network_exists(&cfg, &target)?;
 
     // Check if already on the target network
     if cfg.network == target {
@@ -107,29 +104,39 @@ fn switch(target: String) -> Result<()> {
     Ok(())
 }
 
+fn validate_url(label: &str, url: &str) -> Result<()> {
+    if url.is_empty() {
+        anyhow::bail!("{} URL cannot be empty", label);
+    }
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        anyhow::bail!("{} URL must start with http:// or https://", label);
+    }
+    Ok(())
+}
+
 fn add_network(
     name: String,
     horizon_url: String,
     soroban_rpc_url: Option<String>,
     friendbot_url: Option<String>,
+    passphrase: Option<String>,
 ) -> Result<()> {
     let mut cfg = config::load()?;
 
-    if !horizon_url.starts_with("http://") && !horizon_url.starts_with("https://") {
-        anyhow::bail!("Horizon URL must start with http:// or https://");
-    }
+    validate_url("Horizon", &horizon_url)?;
 
     if let Some(ref url) = soroban_rpc_url {
-        if !url.starts_with("http://") && !url.starts_with("https://") {
-            anyhow::bail!("Soroban RPC URL must start with http:// or https://");
-        }
+        validate_url("Soroban RPC", url)?;
     }
 
     if let Some(ref url) = friendbot_url {
-        if !url.starts_with("http://") && !url.starts_with("https://") {
-            anyhow::bail!("Friendbot URL must start with http:// or https://");
-        }
+        validate_url("Friendbot", url)?;
     }
+
+    // Normalize trailing slashes so URL construction is consistent downstream
+    let horizon_url = horizon_url.trim_end_matches('/').to_string();
+    let soroban_rpc_url = soroban_rpc_url.map(|u| u.trim_end_matches('/').to_string());
+    let friendbot_url = friendbot_url.map(|u| u.trim_end_matches('/').to_string());
 
     config::add_custom_network(
         &mut cfg,
@@ -137,6 +144,7 @@ fn add_network(
         horizon_url.clone(),
         soroban_rpc_url.clone(),
         friendbot_url.clone(),
+        passphrase,
     )?;
     config::save(&cfg)?;
 
@@ -161,7 +169,7 @@ fn test_network(network_name: Option<String>) -> Result<()> {
     p::info(&format!("Horizon: {}", net_cfg.horizon_url));
 
     // Test Horizon endpoint
-    match ureq::get(&format!("{}health", net_cfg.horizon_url)).call() {
+    match ureq::get(&format!("{}/health", net_cfg.horizon_url)).call() {
         Ok(_) => {
             p::success("✓ Horizon endpoint is reachable");
         }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -182,6 +182,8 @@ pub struct NetworkConfig {
     pub horizon_url: String,
     pub soroban_rpc_url: Option<String>,
     pub friendbot_url: Option<String>,
+    #[serde(default)]
+    pub passphrase: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -213,6 +215,7 @@ impl Default for Config {
                 horizon_url: "https://horizon-testnet.stellar.org".to_string(),
                 soroban_rpc_url: Some("https://soroban-testnet.stellar.org".to_string()),
                 friendbot_url: Some("https://friendbot.stellar.org".to_string()),
+                passphrase: Some("Test SDF Network ; September 2015".to_string()),
             },
         );
         networks.insert(
@@ -221,6 +224,7 @@ impl Default for Config {
                 horizon_url: "https://horizon.stellar.org".to_string(),
                 soroban_rpc_url: Some("https://mainnet.sorobanrpc.com".to_string()),
                 friendbot_url: None,
+                passphrase: Some("Public Global Stellar Network ; September 2015".to_string()),
             },
         );
         networks.insert(
@@ -229,6 +233,7 @@ impl Default for Config {
                 horizon_url: "http://localhost:8000".to_string(),
                 soroban_rpc_url: Some("http://localhost:8000/rpc".to_string()),
                 friendbot_url: None,
+                passphrase: Some("Test SDF Network ; September 2015".to_string()),
             },
         );
 
@@ -349,6 +354,9 @@ pub fn load() -> Result<Config> {
     // Migrate config if needed
     config = migrate_config(config)?;
 
+    // Guarantee built-in networks are always present
+    ensure_default_networks(&mut config);
+
     // Save migrated config
     if config.version != CURRENT_CONFIG_VERSION {
         save(&config)?;
@@ -461,6 +469,45 @@ mod tests {
     }
 }
 
+/// Returns the network passphrase for transaction signing.
+/// Checks the config for a custom passphrase; falls back to well-known defaults.
+pub fn get_network_passphrase(network: &str) -> String {
+    if let Ok(cfg) = load() {
+        if let Some(net_cfg) = cfg.networks.get(network) {
+            if let Some(passphrase) = &net_cfg.passphrase {
+                return passphrase.clone();
+            }
+        }
+    }
+    match network {
+        "mainnet" => "Public Global Stellar Network ; September 2015".to_string(),
+        _ => "Test SDF Network ; September 2015".to_string(),
+    }
+}
+
+/// Ensures the three built-in networks are present in the config's network map.
+/// Safe to call on any Config — existing entries are never overwritten.
+pub fn ensure_default_networks(cfg: &mut Config) {
+    cfg.networks.entry("testnet".to_string()).or_insert_with(|| NetworkConfig {
+        horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+        soroban_rpc_url: Some("https://soroban-testnet.stellar.org".to_string()),
+        friendbot_url: Some("https://friendbot.stellar.org".to_string()),
+        passphrase: Some("Test SDF Network ; September 2015".to_string()),
+    });
+    cfg.networks.entry("mainnet".to_string()).or_insert_with(|| NetworkConfig {
+        horizon_url: "https://horizon.stellar.org".to_string(),
+        soroban_rpc_url: Some("https://mainnet.sorobanrpc.com".to_string()),
+        friendbot_url: None,
+        passphrase: Some("Public Global Stellar Network ; September 2015".to_string()),
+    });
+    cfg.networks.entry("docker-testnet".to_string()).or_insert_with(|| NetworkConfig {
+        horizon_url: "http://localhost:8000".to_string(),
+        soroban_rpc_url: Some("http://localhost:8000/rpc".to_string()),
+        friendbot_url: None,
+        passphrase: Some("Test SDF Network ; September 2015".to_string()),
+    });
+}
+
 pub fn save(config: &Config) -> Result<()> {
     let dir = config_dir();
     if !dir.exists() {
@@ -479,13 +526,22 @@ pub fn get_network_config(cfg: &Config, network: &str) -> Result<NetworkConfig> 
         .ok_or_else(|| anyhow::anyhow!("Network '{}' not found in configuration", network))
 }
 
+const RESERVED_NETWORKS: &[&str] = &["testnet", "mainnet", "docker-testnet"];
+
 pub fn add_custom_network(
     config: &mut Config,
     name: String,
     horizon_url: String,
     soroban_rpc_url: Option<String>,
     friendbot_url: Option<String>,
+    passphrase: Option<String>,
 ) -> Result<()> {
+    if RESERVED_NETWORKS.contains(&name.as_str()) {
+        anyhow::bail!(
+            "'{}' is a reserved network name ('testnet', 'mainnet', 'docker-testnet'). Choose a different name.",
+            name
+        );
+    }
     if config.networks.contains_key(&name) {
         anyhow::bail!("Network '{}' already exists", name);
     }
@@ -495,6 +551,7 @@ pub fn add_custom_network(
             horizon_url,
             soroban_rpc_url,
             friendbot_url,
+            passphrase,
         },
     );
     Ok(())

--- a/src/utils/horizon.rs
+++ b/src/utils/horizon.rs
@@ -418,10 +418,7 @@ fn build_batch_transaction_xdr(
         anyhow::bail!("Batch transaction requires at least one operation");
     }
 
-    let _network_passphrase = match network {
-        "mainnet" => "Public Global Stellar Network ; September 2015",
-        _ => "Test SDF Network ; September 2015",
-    };
+    let _network_passphrase = config::get_network_passphrase(network);
 
     let op_parts: Vec<String> = operations
         .iter()
@@ -468,11 +465,8 @@ fn build_account_merge_transaction_xdr(
     Ok(general_purpose::STANDARD.encode(mock_xdr))
 }
 
-fn network_passphrase(network: &str) -> &'static str {
-    match network {
-        "mainnet" => "Public Global Stellar Network ; September 2015",
-        _ => "Test SDF Network ; September 2015",
-    }
+fn network_passphrase(network: &str) -> String {
+    config::get_network_passphrase(network)
 }
 
 fn build_payment_transaction_xdr(
@@ -511,10 +505,7 @@ fn sign_transaction_xdr(transaction_xdr: &str, secret_key: &str, network: &str) 
     // This is a simplified mock implementation
     // In production, you'd use stellar-xdr and ed25519 signing
 
-    let _network_passphrase = match network {
-        "mainnet" => "Public Global Stellar Network ; September 2015",
-        _ => "Test SDF Network ; September 2015",
-    };
+    let _network_passphrase = config::get_network_passphrase(network);
 
     // Mock signing - in reality this would involve:
     // 1. Decode the transaction XDR

--- a/src/utils/multisig.rs
+++ b/src/utils/multisig.rs
@@ -1,3 +1,4 @@
+use crate::utils::config;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -235,10 +236,7 @@ pub fn build_multisig_transaction_xdr(
     // This is a simplified mock implementation
     // In production, use stellar-xdr to build proper transaction XDR
 
-    let _network_passphrase = match network {
-        "mainnet" => "Public Global Stellar Network ; September 2015",
-        _ => "Test SDF Network ; September 2015",
-    };
+    let _network_passphrase = config::get_network_passphrase(network);
 
     // Mock XDR generation
     let mock_xdr = format!(
@@ -260,10 +258,7 @@ pub fn sign_transaction_partial(
     // This is a simplified mock implementation
     // In production, use stellar-xdr and ed25519 signing
 
-    let _network_passphrase = match network {
-        "mainnet" => "Public Global Stellar Network ; September 2015",
-        _ => "Test SDF Network ; September 2015",
-    };
+    let _network_passphrase = config::get_network_passphrase(network);
 
     // Mock signing
     let signature = format!("sig_{}_{}", &secret_key[..8], &transaction_xdr[..16]);

--- a/src/utils/soroban.rs
+++ b/src/utils/soroban.rs
@@ -1,4 +1,4 @@
-use crate::utils::config::WalletEntry;
+use crate::utils::config::{self, WalletEntry};
 use anyhow::{Context, Result};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use stellar_strkey::{ed25519, Contract};
@@ -107,7 +107,7 @@ pub fn simulate_transaction(
     arg_types: &[String],
     network: &str,
 ) -> Result<SimulationResult> {
-    let rpc_url = get_rpc_url(network);
+    let rpc_url = get_rpc_url(network)?;
 
     // Convert arguments to XDR ScVal format
     let xdr_args = encode_arguments(args, arg_types)?;
@@ -144,7 +144,7 @@ pub fn simulate_deploy_transaction(
     network: &str,
     wallet: &WalletEntry,
 ) -> Result<SimulationResult> {
-    let rpc_url = get_rpc_url(network);
+    let rpc_url = get_rpc_url(network)?;
     let request = SorobanRpcRequest {
         jsonrpc: "2.0".to_string(),
         id: 1,
@@ -173,7 +173,7 @@ pub fn submit_transaction(
     network: &str,
     wallet: &WalletEntry,
 ) -> Result<TransactionResult> {
-    let rpc_url = get_rpc_url(network);
+    let rpc_url = get_rpc_url(network)?;
 
     // Convert arguments to XDR ScVal format
     let xdr_args = encode_arguments(args, arg_types)?;
@@ -210,7 +210,8 @@ pub fn upload_wasm(
 ) -> Result<String> {
     use std::process::Command;
 
-    let rpc_url = get_rpc_url(network);
+    let rpc_url = get_rpc_url(network)?;
+    let passphrase = config::get_network_passphrase(network);
 
     let output = Command::new("stellar")
         .args([
@@ -223,11 +224,7 @@ pub fn upload_wasm(
             "--source",
             &wallet.name,
             "--network-passphrase",
-            if network == "mainnet" {
-                "Public Global Stellar Network ; September 2015"
-            } else {
-                "Test SDF Network ; September 2015"
-            },
+            &passphrase,
         ])
         .output()
         .context("Failed to run `stellar contract upload`. Is the Stellar CLI installed?")?;
@@ -255,7 +252,7 @@ pub fn inspect_contract(contract_id: &str, network: &str) -> Result<ContractInsp
         }),
     };
 
-    let response: GetLedgerEntriesResult = rpc_request_with_url(&get_rpc_url(network), request)
+    let response: GetLedgerEntriesResult = rpc_request_with_url(&get_rpc_url(network)?, request)
         .with_context(|| {
             format!(
                 "Failed to inspect contract '{}' on {}",
@@ -266,15 +263,25 @@ pub fn inspect_contract(contract_id: &str, network: &str) -> Result<ContractInsp
     parse_contract_inspect_result(contract_id, network, response)
 }
 
-fn get_rpc_url(network: &str) -> String {
-    match network {
-        "mainnet" => "https://mainnet.sorobanrpc.com".to_string(),
-        "docker-testnet" => "http://localhost:8000/rpc".to_string(),
-        _ => "https://soroban-testnet.stellar.org".to_string(),
+fn get_rpc_url(network: &str) -> Result<String> {
+    let cfg = config::load()?;
+    match cfg.networks.get(network) {
+        Some(net_cfg) => match &net_cfg.soroban_rpc_url {
+            Some(url) => Ok(url.clone()),
+            None => anyhow::bail!(
+                "Network '{}' has no Soroban RPC URL configured. \
+                 Use 'starforge network add --soroban-rpc-url <url>' to set one.",
+                network
+            ),
+        },
+        None => anyhow::bail!(
+            "Network '{}' not found. Use 'starforge network add' to create it.",
+            network
+        ),
     }
 }
 
-pub fn rpc_url(network: &str) -> String {
+pub fn rpc_url(network: &str) -> Result<String> {
     get_rpc_url(network)
 }
 

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -77,3 +77,95 @@ fn deploy_help_documents_flags() {
     assert!(stdout.contains("--simulate"));
     assert!(stdout.contains("--execute"));
 }
+
+#[test]
+fn network_add_custom_succeeds() {
+    let output = starforge()
+        .args([
+            "network",
+            "add",
+            "my-smoke-test-net",
+            "--horizon-url",
+            "https://example.com/horizon",
+            "--soroban-rpc-url",
+            "https://example.com/rpc",
+        ])
+        .output()
+        .expect("spawn network add");
+    assert_success(&output, "starforge network add");
+
+    // Verify it appears in the list
+    let list_output = starforge()
+        .args(["network", "show"])
+        .output()
+        .expect("spawn network show");
+    assert_success(&list_output, "starforge network show");
+    let stdout = String::from_utf8_lossy(&list_output.stdout);
+    assert!(
+        stdout.to_lowercase().contains("my-smoke-test-net"),
+        "expected 'my-smoke-test-net' in network show output"
+    );
+}
+
+#[test]
+fn network_add_rejects_empty_horizon_url() {
+    let output = starforge()
+        .args(["network", "add", "bad-net", "--horizon-url", ""])
+        .output()
+        .expect("spawn network add with empty url");
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for empty horizon URL"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be empty") || stderr.contains("must start with"),
+        "expected URL validation message in stderr, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn network_switch_to_mainnet_succeeds() {
+    let output = starforge()
+        .args(["network", "switch", "mainnet"])
+        .output()
+        .expect("spawn network switch mainnet");
+    assert_success(&output, "starforge network switch mainnet");
+}
+
+#[test]
+fn network_switch_unknown_network_fails() {
+    let output = starforge()
+        .args(["network", "switch", "does-not-exist-xyz"])
+        .output()
+        .expect("spawn network switch unknown");
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for unknown network"
+    );
+}
+
+#[test]
+fn network_add_reserved_name_fails() {
+    let output = starforge()
+        .args([
+            "network",
+            "add",
+            "testnet",
+            "--horizon-url",
+            "https://example.com",
+        ])
+        .output()
+        .expect("spawn network add testnet");
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when overwriting reserved network name"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("reserved"),
+        "expected 'reserved' in stderr, got: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
Closes #201 

  Fixes eight bugs found in the network management flow:

  - soroban.rs: get_rpc_url() now reads soroban_rpc_url from config instead
    of returning hardcoded URLs for custom networks
  - network.rs: removed duplicate Add match arm; fixed health check URL
    construction (missing slash before /health)
  - network.rs: switch() now uses validate_network_exists() instead of raw
    contains_key, accepting built-in networks on old config files
  - config.rs: ensure_default_networks() called on load() guarantees built-in
    networks are always present regardless of what is on disk
  - Passphrase handling unified across soroban.rs, horizon.rs, multisig.rs
    via config::get_network_passphrase()

  URL validation improvements:
  - Empty string check with clear error message
  - Trailing slash normalization before persistence
  - Reserved network names (testnet, mainnet, docker-testnet) rejected on add

  New field:
  - NetworkConfig.passphrase for custom network transaction signing

  Smoke tests added:
  - network_add_custom_succeeds
  - network_add_rejects_empty_horizon_url
  - network_switch_to_mainnet_succeeds
  - network_switch_unknown_network_fails
  - network_add_reserved_name_fails