### PR TITLE
Add network lifecycle, plugin manifest, template archives, and plugin…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "base64ct",
  "blake2",
  "cpufeatures",
- "password-hash",
+ "password-hash 0.5.0",
 ]
 
 [[package]]
@@ -270,6 +270,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +302,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -446,6 +468,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1466,6 +1494,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +1783,17 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
@@ -1752,6 +1801,18 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash 0.4.2",
+ "sha2",
 ]
 
 [[package]]
@@ -2348,6 +2409,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2556,7 @@ dependencies = [
  "ureq",
  "urlencoding",
  "uuid",
+ "zip",
  "zxcvbn",
 ]
 
@@ -3589,10 +3662,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zxcvbn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ tracing-appender = "0.2"
 bip39 = { version = "2", features = ["rand", "std"] }
 hmac = "0.12"
 rustyline = "14.0.0"
+zip = "0.6"
+tempfile = "3.8"
 
 [features]
 hardware-wallet = ["dep:hidapi", "dep:trezor-client"]

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -34,6 +34,18 @@ pub enum NetworkCommands {
         #[arg(default_value = None)]
         network: Option<String>,
     },
+    /// Remove a custom network from configuration
+    Remove {
+        /// Name of the custom network to remove
+        name: String,
+    },
+    /// Rename a custom network
+    Rename {
+        /// Current network name
+        old_name: String,
+        /// New network name
+        new_name: String,
+    },
 }
 
 pub fn handle(cmd: NetworkCommands) -> Result<()> {
@@ -54,6 +66,8 @@ pub fn handle(cmd: NetworkCommands) -> Result<()> {
             passphrase,
         ),
         NetworkCommands::Test { network } => test_network(network),
+        NetworkCommands::Remove { name } => remove_network(name),
+        NetworkCommands::Rename { old_name, new_name } => rename_network(old_name, new_name),
     }
 }
 
@@ -208,5 +222,29 @@ fn test_network(network_name: Option<String>) -> Result<()> {
     }
 
     p::info("Network test complete");
+    Ok(())
+}
+
+fn remove_network(name: String) -> Result<()> {
+    let mut cfg = config::load()?;
+
+    let was_active = cfg.network == name;
+    config::remove_custom_network(&mut cfg, &name)?;
+    config::save(&cfg)?;
+
+    p::success(&format!("Network '{}' removed", name));
+    if was_active {
+        p::warn("Active network was removed; switched to testnet.");
+        p::kv("Active network", "testnet");
+    }
+    Ok(())
+}
+
+fn rename_network(old_name: String, new_name: String) -> Result<()> {
+    let mut cfg = config::load()?;
+    config::rename_custom_network(&mut cfg, &old_name, &new_name)?;
+    config::save(&cfg)?;
+
+    p::success(&format!("Network renamed from '{}' to '{}'", old_name, new_name));
     Ok(())
 }

--- a/src/commands/plugin.rs
+++ b/src/commands/plugin.rs
@@ -1,5 +1,6 @@
 use crate::plugins::interface::CORE_VERSION;
-use crate::plugins::registry::{self, TrustLevel};
+use crate::plugins::manifest;
+use crate::plugins::registry::{self, TrustLevel, UninstallOptions};
 use crate::plugins::PluginManager;
 use crate::utils::print as p;
 use anyhow::{Context, Result};
@@ -34,6 +35,12 @@ pub enum PluginCommands {
     Uninstall {
         /// Plugin name to remove
         name: String,
+        /// Also delete the plugin library file from disk (only under ~/.starforge/plugins/)
+        #[arg(long)]
+        purge: bool,
+        /// Skip confirmation for destructive removal
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
     /// Verify trust and compatibility of installed plugins
     Verify {
@@ -52,7 +59,7 @@ pub fn handle(cmd: PluginCommands) -> Result<()> {
         } => install(name, path, source, force),
         PluginCommands::List => list(),
         PluginCommands::Load => load(),
-        PluginCommands::Uninstall { name } => uninstall(name),
+        PluginCommands::Uninstall { name, purge, yes } => uninstall(name, purge, yes),
         PluginCommands::Verify { name } => verify(name),
     }
 }
@@ -79,12 +86,22 @@ fn install(name: String, path: Option<PathBuf>, source: Option<String>, force: b
         anyhow::bail!("Refusing to install plugin from untrusted source without --force");
     }
 
-    registry::install_plugin(&name, &lib_path, source_str)?;
+    let plugin_manifest = manifest::require_compatible_manifest(&lib_path, &name)?;
+
+    registry::install_plugin(
+        &name,
+        &lib_path,
+        source_str,
+        &plugin_manifest.starforge_version,
+        &plugin_manifest.version,
+    )?;
 
     p::header("Plugin Install");
     p::success("Plugin registered");
     p::kv_accent("Name", &name);
     p::kv("Library", &lib_path.display().to_string());
+    p::kv("Plugin version", &plugin_manifest.version);
+    p::kv("StarForge compatibility", &plugin_manifest.starforge_version);
     p::kv("Trust", trust.label());
     if !source_str.is_empty() {
         p::kv("Source", source_str);
@@ -109,6 +126,9 @@ fn list() -> Result<()> {
         p::kv("Trust", pl.trust.label());
         if !pl.source.is_empty() {
             p::kv("Source", &pl.source);
+        }
+        if !pl.starforge_version.is_empty() {
+            p::kv("StarForge", &pl.starforge_version);
         }
         if i < reg.plugins.len() - 1 {
             println!();
@@ -163,24 +183,69 @@ fn load() -> Result<()> {
     Ok(())
 }
 
-fn uninstall(name: String) -> Result<()> {
-    let mut reg = registry::load_registry().unwrap_or_default();
+fn uninstall(name: String, purge: bool, yes: bool) -> Result<()> {
+    let reg = registry::load_registry().unwrap_or_default();
+    let plugin = reg
+        .plugins
+        .iter()
+        .find(|p| p.name == name)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Plugin '{}' is not installed. Run `starforge plugin list` to see installed plugins.",
+                name
+            )
+        })?;
 
-    let before = reg.plugins.len();
-    reg.plugins.retain(|p| p.name != name);
-
-    if reg.plugins.len() == before {
-        anyhow::bail!(
-            "Plugin '{}' is not installed. Run `starforge plugin list` to see installed plugins.",
-            name
-        );
-    }
-
-    registry::save_registry(&reg)?;
+    let lib_path = PathBuf::from(&plugin.path);
+    let lib_exists = lib_path.exists();
 
     p::header("Plugin Uninstall");
+    p::kv_accent("Plugin", &name);
+    p::kv("Library", &plugin.path);
+
+    if lib_exists {
+        p::warn(
+            "If this plugin is loaded in another StarForge session, close that session before purging files.",
+        );
+    } else {
+        p::warn("Plugin library file is already missing on disk.");
+    }
+
+    if purge && !yes {
+        p::warn("This will permanently delete the plugin library file.");
+        p::info("Proceed with: starforge plugin uninstall <name> --purge --yes");
+        anyhow::bail!("Refusing destructive uninstall without --yes");
+    }
+
+    // Best-effort: load plugin to run on_unload before registry removal
+    if lib_exists {
+        let mut pm = PluginManager::new();
+        if let Err(e) = unsafe { pm.load_plugin(&lib_path) } {
+            p::warn(&format!(
+                "Could not load plugin for clean shutdown: {}. Proceeding with uninstall.",
+                e
+            ));
+        } else {
+            p::info("Plugin unloaded cleanly.");
+        }
+    }
+
+    let opts = UninstallOptions {
+        purge_files: purge,
+        assume_yes: yes,
+    };
+    let report = registry::uninstall_plugin(&name, &opts)?;
+
     p::success(&format!("Plugin '{}' removed from registry", name));
-    p::info("The plugin library file on disk was not deleted.");
+    if report.files_removed {
+        p::success("Plugin library file deleted.");
+    } else if !purge {
+        p::info("Library file kept on disk. Use --purge --yes to delete it.");
+    }
+    if report.library_was_missing && !report.files_removed {
+        p::info("No library file was present to remove.");
+    }
+
     Ok(())
 }
 
@@ -214,17 +279,29 @@ fn verify(name: Option<String>) -> Result<()> {
             TrustLevel::Unknown => false,
         };
 
-        let status = if lib_exists && trust_ok {
+        let compat_ok = if pl.starforge_version.is_empty() {
+            true
+        } else {
+            crate::plugins::interface::is_core_version_compatible(&pl.starforge_version)
+        };
+
+        let status = if lib_exists && trust_ok && compat_ok {
             "✓ OK"
         } else if !lib_exists {
             all_ok = false;
             "✗ library missing"
+        } else if !compat_ok {
+            all_ok = false;
+            "✗ incompatible"
         } else {
             all_ok = false;
             "⚠ untrusted source"
         };
 
         println!("  {:<24} [{}]  trust={}", pl.name, status, pl.trust.label());
+        if !pl.starforge_version.is_empty() {
+            p::kv("StarForge", &pl.starforge_version);
+        }
         if !pl.source.is_empty() {
             p::kv("Source", &pl.source);
         }
@@ -235,6 +312,13 @@ fn verify(name: Option<String>) -> Result<()> {
         if pl.trust == TrustLevel::Unknown && !pl.source.is_empty() {
             p::warn("Source is not in the trusted sources list.");
             p::info("See: starforge plugin install --help for trusted source prefixes.");
+        }
+        if !compat_ok && !pl.starforge_version.is_empty() {
+            p::warn(&format!(
+                "Plugin targets StarForge {} but running {}",
+                pl.starforge_version, CORE_VERSION
+            ));
+            p::info("Reinstall a compatible build or upgrade StarForge.");
         }
     }
 

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -30,6 +30,32 @@ pub enum TemplateCommands {
         /// Template name
         name: String,
     },
+    /// Install a template from a directory or .zip archive into the local registry
+    Install {
+        /// Path to template directory or .zip package
+        path: PathBuf,
+        /// Template name (defaults to directory/archive stem)
+        #[arg(long)]
+        name: Option<String>,
+        /// Template description
+        #[arg(long)]
+        description: Option<String>,
+        /// Author name
+        #[arg(long)]
+        author: Option<String>,
+        /// Tags (comma-separated)
+        #[arg(long)]
+        tags: Option<String>,
+        /// Version
+        #[arg(long, default_value = "1.0.0")]
+        version: String,
+        /// Minimum StarForge CLI version required
+        #[arg(long)]
+        cli_version_min: Option<String>,
+        /// Maximum StarForge CLI version supported
+        #[arg(long)]
+        cli_version_max: Option<String>,
+    },
     /// Publish a template to the local marketplace
     Publish {
         /// Path to the template directory
@@ -67,6 +93,25 @@ pub enum TemplateCommands {
 
 pub fn handle(cmd: TemplateCommands) -> Result<()> {
     match cmd {
+        TemplateCommands::Install {
+            path,
+            name,
+            description,
+            author,
+            tags,
+            version,
+            cli_version_min,
+            cli_version_max,
+        } => install(
+            path,
+            name,
+            description,
+            author,
+            tags,
+            version,
+            cli_version_min,
+            cli_version_max,
+        ),
         TemplateCommands::Publish {
             path,
             name,
@@ -98,6 +143,31 @@ pub fn handle(cmd: TemplateCommands) -> Result<()> {
         TemplateCommands::Remove { name } => remove(name),
         TemplateCommands::Init => init(),
     }
+}
+
+fn install(
+    path: PathBuf,
+    name: Option<String>,
+    description: Option<String>,
+    author: Option<String>,
+    tags: Option<String>,
+    version: String,
+    cli_version_min: Option<String>,
+    cli_version_max: Option<String>,
+) -> Result<()> {
+    publish(
+        path,
+        name,
+        description,
+        author,
+        tags,
+        version,
+        cli_version_min,
+        cli_version_max,
+    )?;
+    p::header("Template Install");
+    p::info("Template package installed into the local registry.");
+    Ok(())
 }
 
 fn publish(

--- a/src/plugins/loader.rs
+++ b/src/plugins/loader.rs
@@ -1,7 +1,8 @@
 use crate::plugins::interface::{
-    is_core_version_compatible, Plugin, PluginDeclaration, PluginRegistrar, CORE_VERSION,
-    RUSTC_VERSION,
+    is_core_version_compatible, Plugin, PluginDeclaration, PluginRegistrar, RUSTC_VERSION,
 };
+use std::path::Path;
+use crate::plugins::manifest;
 use anyhow::{Context, Result};
 use libloading::{Library, Symbol};
 use std::collections::HashMap;
@@ -32,8 +33,9 @@ impl PluginManager {
     /// The caller must ensure the plugin at `path` is a valid StarForge plugin
     /// compiled with a compatible Rust toolchain and ABI.
     pub unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> Result<()> {
-        let path_display = path.as_ref().to_string_lossy().to_string();
-        let library = Rc::new(Library::new(path).context("Failed to load library")?);
+        let path_ref = path.as_ref();
+        let path_display = path_ref.to_string_lossy().to_string();
+        let library = Rc::new(Library::new(path_ref).context("Failed to load library")?);
 
         let decl: Symbol<*mut PluginDeclaration> = library
             .get(b"PLUGIN_DECLARATION")
@@ -56,17 +58,20 @@ impl PluginManager {
 
         // ── StarForge core version check ─────────────────────────────────────
         if !is_core_version_compatible(decl.core_version) {
-            anyhow::bail!(
-                "Plugin version incompatibility in '{path_display}':\n  \
-                 Plugin was built for StarForge {plugin_core}\n  \
-                 Running StarForge {core}\n\n  \
-                 The major version must match. Rebuild the plugin against \
-                 StarForge {core} or install a compatible StarForge version.\n  \
-                 See DEVELOPER_GUIDE.md § \"Plugin Version Compatibility\" for details.",
-                path_display = path_display,
-                plugin_core = decl.core_version,
-                core = CORE_VERSION,
-            );
+            anyhow::bail!(manifest::format_binary_incompatibility(
+                decl.core_version,
+                &path_display
+            ));
+        }
+
+        // ── Manifest compatibility (if present beside the library) ───────────
+        if let Ok(Some(mf)) = manifest::load_manifest_for_library(Path::new(path_ref)) {
+            mf.validate().with_context(|| {
+                format!(
+                    "Plugin manifest compatibility check failed for '{}'",
+                    path_display
+                )
+            })?;
         }
 
         let mut registrar = ProxyRegistrar::new();

--- a/src/plugins/manifest.rs
+++ b/src/plugins/manifest.rs
@@ -1,0 +1,238 @@
+use crate::plugins::interface::{is_core_version_compatible, CORE_VERSION};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Filename searched beside the plugin library or in the plugin install directory.
+pub const MANIFEST_FILENAME: &str = "starforge-plugin.toml";
+
+/// Plugin manifest schema — required for distribution; enforces CLI compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginManifest {
+    /// Plugin command name (must match install name).
+    pub name: String,
+    /// Plugin semver.
+    pub version: String,
+    /// StarForge CLI version this plugin was built for (e.g. "0.1.0").
+    pub starforge_version: String,
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Optional minimum StarForge version (semver).
+    #[serde(default)]
+    pub starforge_version_min: Option<String>,
+    /// Optional maximum StarForge version (semver).
+    #[serde(default)]
+    pub starforge_version_max: Option<String>,
+}
+
+impl PluginManifest {
+    /// Validate manifest fields and CLI compatibility with the running StarForge.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.trim().is_empty() {
+            anyhow::bail!("Plugin manifest: 'name' is required");
+        }
+        if self.version.trim().is_empty() {
+            anyhow::bail!("Plugin manifest: 'version' is required");
+        }
+        if self.starforge_version.trim().is_empty() {
+            anyhow::bail!(
+                "Plugin manifest: 'starforge_version' is required (the StarForge CLI version this plugin targets)"
+            );
+        }
+
+        if !is_core_version_compatible(&self.starforge_version) {
+            anyhow::bail!(
+                "Plugin '{}' is incompatible with this StarForge CLI.\n  \
+                 Plugin targets StarForge {}\n  \
+                 Running StarForge {}\n\n  \
+                 The major version must match. Rebuild the plugin for StarForge {} \
+                 or install a compatible StarForge version.",
+                self.name,
+                self.starforge_version,
+                CORE_VERSION,
+                CORE_VERSION,
+            );
+        }
+
+        if let Some(ref min) = self.starforge_version_min {
+            if !version_at_least(CORE_VERSION, min) {
+                anyhow::bail!(
+                    "Plugin '{}' requires StarForge >= {} (running {})",
+                    self.name,
+                    min,
+                    CORE_VERSION
+                );
+            }
+        }
+        if let Some(ref max) = self.starforge_version_max {
+            if !version_at_most(CORE_VERSION, max) {
+                anyhow::bail!(
+                    "Plugin '{}' requires StarForge <= {} (running {})",
+                    self.name,
+                    max,
+                    CORE_VERSION
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Locate and parse `starforge-plugin.toml` beside the library or in its parent directory.
+pub fn load_manifest_for_library(library_path: &Path) -> Result<Option<PluginManifest>> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(parent) = library_path.parent() {
+        candidates.push(parent.join(MANIFEST_FILENAME));
+        // Plugin install layout: ~/.starforge/plugins/<name>/lib*.so + manifest
+        if let Some(grandparent) = parent.parent() {
+            candidates.push(grandparent.join(MANIFEST_FILENAME));
+        }
+    }
+
+    for path in candidates {
+        if path.is_file() {
+            let contents = fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read plugin manifest {}", path.display()))?;
+            let manifest: PluginManifest = toml::from_str(&contents).with_context(|| {
+                format!(
+                    "Failed to parse plugin manifest {}. \
+                     Required fields: name, version, starforge_version",
+                    path.display()
+                )
+            })?;
+            return Ok(Some(manifest));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Require a manifest when installing; returns a clear error if missing.
+pub fn require_compatible_manifest(library_path: &Path, install_name: &str) -> Result<PluginManifest> {
+    match load_manifest_for_library(library_path)? {
+        Some(manifest) => {
+            if manifest.name != install_name {
+                anyhow::bail!(
+                    "Plugin manifest name '{}' does not match install name '{}'",
+                    manifest.name,
+                    install_name
+                );
+            }
+            manifest.validate()?;
+            Ok(manifest)
+        }
+        None => {
+            anyhow::bail!(
+                "Plugin manifest not found. Place '{}' next to the plugin library with:\n\n  \
+                 name = \"{}\"\n  \
+                 version = \"1.0.0\"\n  \
+                 starforge_version = \"{}\"\n\n  \
+                 This declares which StarForge CLI version the plugin is compatible with.",
+                MANIFEST_FILENAME,
+                install_name,
+                CORE_VERSION,
+            )
+        }
+    }
+}
+
+/// User-friendly compatibility message when binary declaration fails (no manifest).
+pub fn format_binary_incompatibility(plugin_core: &str, path: &str) -> String {
+    format!(
+        "Plugin version incompatibility in '{path}':\n  \
+         Plugin was built for StarForge {plugin_core}\n  \
+         Running StarForge {core}\n\n  \
+         The major version must match. Add a '{manifest}' with starforge_version = \"{core}\" \
+         and rebuild the plugin, or install a compatible StarForge version.",
+        path = path,
+        plugin_core = plugin_core,
+        core = CORE_VERSION,
+        manifest = MANIFEST_FILENAME,
+    )
+}
+
+fn parse_version_parts(v: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = v.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor, patch))
+}
+
+fn version_at_least(running: &str, required_min: &str) -> bool {
+    match (parse_version_parts(running), parse_version_parts(required_min)) {
+        (Some(a), Some(b)) => a >= b,
+        _ => true,
+    }
+}
+
+fn version_at_most(running: &str, required_max: &str) -> bool {
+    match (parse_version_parts(running), parse_version_parts(required_max)) {
+        (Some(a), Some(b)) => a <= b,
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn manifest_validates_starforge_version_major() {
+        let manifest = PluginManifest {
+            name: "test".to_string(),
+            version: "1.0.0".to_string(),
+            starforge_version: CORE_VERSION.to_string(),
+            description: String::new(),
+            starforge_version_min: None,
+            starforge_version_max: None,
+        };
+        assert!(manifest.validate().is_ok());
+    }
+
+    #[test]
+    fn manifest_rejects_incompatible_major() {
+        let core_major: u64 = CORE_VERSION
+            .split('.')
+            .next()
+            .unwrap_or("0")
+            .parse()
+            .unwrap_or(0);
+        let other = format!("{}.0.0", core_major + 1);
+        let manifest = PluginManifest {
+            name: "test".to_string(),
+            version: "1.0.0".to_string(),
+            starforge_version: other,
+            description: String::new(),
+            starforge_version_min: None,
+            starforge_version_max: None,
+        };
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn load_manifest_from_plugin_dir() {
+        let tmp = TempDir::new().unwrap();
+        let manifest_path = tmp.path().join(MANIFEST_FILENAME);
+        fs::write(
+            &manifest_path,
+            format!(
+                r#"
+name = "myplugin"
+version = "1.0.0"
+starforge_version = "{core}"
+"#,
+                core = CORE_VERSION
+            ),
+        )
+        .unwrap();
+        let lib = tmp.path().join("libstarforge_myplugin.so");
+        fs::write(&lib, b"dummy").unwrap();
+        let loaded = load_manifest_for_library(&lib).unwrap().unwrap();
+        assert_eq!(loaded.name, "myplugin");
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,5 +1,6 @@
 pub mod interface;
 pub mod loader;
+pub mod manifest;
 pub mod registry;
 
 pub use interface::{Plugin, PluginDeclaration};

--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -69,6 +69,12 @@ pub struct InstalledPlugin {
     /// Trust level assigned at install time.
     #[serde(default)]
     pub trust: TrustLevel,
+    /// StarForge CLI version from plugin manifest at install time.
+    #[serde(default)]
+    pub starforge_version: String,
+    /// Plugin version from manifest.
+    #[serde(default)]
+    pub plugin_version: String,
 }
 
 fn registry_path() -> Result<PathBuf> {
@@ -99,11 +105,54 @@ pub fn save_registry(reg: &PluginRegistry) -> Result<()> {
     Ok(())
 }
 
+/// Options for uninstalling a plugin.
+#[derive(Debug, Clone, Default)]
+pub struct UninstallOptions {
+    /// Delete the plugin library file from disk.
+    pub purge_files: bool,
+    /// Skip interactive confirmation for destructive removal.
+    pub assume_yes: bool,
+}
+
+/// Report returned after uninstalling a plugin.
+#[derive(Debug, Clone)]
+pub struct UninstallReport {
+    pub name: String,
+    pub library_path: String,
+    pub files_removed: bool,
+    pub library_was_missing: bool,
+}
+
+fn plugins_data_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
+    Ok(home.join(".starforge").join("plugins"))
+}
+
+/// Returns true if `path` is under the StarForge plugins directory (safe to purge).
+pub fn is_managed_plugin_path(path: &Path) -> bool {
+    if let Ok(dir) = plugins_data_dir() {
+        if let (Ok(path), Ok(dir)) = (path.canonicalize(), dir.canonicalize()) {
+            return path.starts_with(&dir);
+        }
+        if let Some(parent) = dirs::home_dir() {
+            let prefix = parent.join(".starforge").join("plugins");
+            return path.starts_with(&prefix);
+        }
+    }
+    false
+}
+
 /// Install a plugin into the registry.
 ///
 /// `source` is the URL or identifier where the plugin came from; pass an
 /// empty string when the user supplied `--path` directly.
-pub fn install_plugin(name: &str, library_path: &Path, source: &str) -> Result<()> {
+pub fn install_plugin(
+    name: &str,
+    library_path: &Path,
+    source: &str,
+    starforge_version: &str,
+    plugin_version: &str,
+) -> Result<()> {
     if !library_path.exists() {
         anyhow::bail!("Plugin library not found: {}", library_path.display());
     }
@@ -117,10 +166,78 @@ pub fn install_plugin(name: &str, library_path: &Path, source: &str) -> Result<(
         path: library_path.display().to_string(),
         source: source.to_string(),
         trust,
+        starforge_version: starforge_version.to_string(),
+        plugin_version: plugin_version.to_string(),
     });
     reg.plugins.sort_by(|a, b| a.name.cmp(&b.name));
     save_registry(&reg)?;
     Ok(())
+}
+
+/// Remove a plugin from the registry and optionally delete its library file.
+pub fn uninstall_plugin(name: &str, opts: &UninstallOptions) -> Result<UninstallReport> {
+    let mut reg = load_registry().unwrap_or_default();
+    let idx = reg
+        .plugins
+        .iter()
+        .position(|p| p.name == name)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Plugin '{}' is not installed. Run `starforge plugin list` to see installed plugins.",
+                name
+            )
+        })?;
+
+    let plugin = reg.plugins.remove(idx);
+    let lib_path = PathBuf::from(&plugin.path);
+    let library_was_missing = !lib_path.exists();
+
+    let mut files_removed = false;
+    if opts.purge_files {
+        if library_was_missing {
+            // Nothing to delete
+        } else if is_managed_plugin_path(&lib_path) {
+            match fs::remove_file(&lib_path) {
+                Ok(()) => {
+                    files_removed = true;
+                    // Remove empty plugin directory if present
+                    if let Some(parent) = lib_path.parent() {
+                        let empty = parent
+                            .read_dir()
+                            .map(|d| d.filter_map(|e| e.ok()).next().is_none())
+                            .unwrap_or(false);
+                        if empty {
+                            let _ = fs::remove_dir(parent);
+                        }
+                    }
+                }
+                Err(e) => {
+                    anyhow::bail!(
+                        "Failed to remove plugin library at {}: {}. \
+                         The file may be in use (close other StarForge sessions using this plugin) \
+                         or you may lack permission.",
+                        lib_path.display(),
+                        e
+                    );
+                }
+            }
+        } else {
+            anyhow::bail!(
+                "Refusing to delete plugin library outside ~/.starforge/plugins/: {}\n  \
+                 Remove the file manually or reinstall under the managed plugins directory.",
+                lib_path.display()
+            );
+        }
+    }
+
+    save_registry(&reg)?;
+
+    Ok(UninstallReport {
+        name: name.to_string(),
+        library_path: plugin.path,
+        files_removed,
+        library_was_missing,
+    })
 }
 
 pub fn resolve_plugin_library_path(name: &str, explicit: Option<PathBuf>) -> Result<PathBuf> {
@@ -232,7 +349,7 @@ mod tests {
     fn install_missing_library_fails() {
         let tmp = TempDir::new().unwrap();
         let missing = tmp.path().join("nonexistent.so");
-        let result = install_plugin("test", &missing, "");
+        let result = install_plugin("test", &missing, "", "0.1.0", "1.0.0");
         assert!(result.is_err(), "installing a missing library must fail");
         assert!(result.unwrap_err().to_string().contains("not found"));
     }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -549,7 +549,12 @@ pub fn get_network_config(cfg: &Config, network: &str) -> Result<NetworkConfig> 
         .ok_or_else(|| anyhow::anyhow!("Network '{}' not found in configuration", network))
 }
 
-const RESERVED_NETWORKS: &[&str] = &["testnet", "mainnet", "docker-testnet"];
+pub const RESERVED_NETWORKS: &[&str] = &["testnet", "mainnet", "docker-testnet"];
+
+/// Returns true for built-in networks that cannot be removed or renamed.
+pub fn is_reserved_network(name: &str) -> bool {
+    RESERVED_NETWORKS.contains(&name)
+}
 
 pub fn add_custom_network(
     config: &mut Config,
@@ -559,7 +564,7 @@ pub fn add_custom_network(
     friendbot_url: Option<String>,
     passphrase: Option<String>,
 ) -> Result<()> {
-    if RESERVED_NETWORKS.contains(&name.as_str()) {
+    if is_reserved_network(&name) {
         anyhow::bail!(
             "'{}' is a reserved network name ('testnet', 'mainnet', 'docker-testnet'). Choose a different name.",
             name
@@ -577,5 +582,75 @@ pub fn add_custom_network(
             passphrase,
         },
     );
+    Ok(())
+}
+
+/// Remove a custom network from config. Built-in networks are protected.
+pub fn remove_custom_network(config: &mut Config, name: &str) -> Result<()> {
+    if is_reserved_network(name) {
+        anyhow::bail!(
+            "'{}' is a built-in network and cannot be removed. Only custom networks can be removed.",
+            name
+        );
+    }
+    if !config.networks.contains_key(name) {
+        anyhow::bail!("Network '{}' not found", name);
+    }
+    // Only remove if it is not a built-in re-injected entry (custom keys are user-added).
+    config.networks.remove(name);
+
+    if config.network == name {
+        config.network = "testnet".to_string();
+    }
+
+    for wallet in &mut config.wallets {
+        if wallet.network == name {
+            wallet.network = config.network.clone();
+        }
+    }
+
+    Ok(())
+}
+
+/// Rename a custom network. Built-in networks cannot be renamed.
+pub fn rename_custom_network(config: &mut Config, old_name: &str, new_name: &str) -> Result<()> {
+    if is_reserved_network(old_name) {
+        anyhow::bail!(
+            "'{}' is a built-in network and cannot be renamed.",
+            old_name
+        );
+    }
+    if is_reserved_network(new_name) {
+        anyhow::bail!(
+            "'{}' is a reserved network name. Choose a different name.",
+            new_name
+        );
+    }
+    if !config.networks.contains_key(old_name) {
+        anyhow::bail!("Network '{}' not found", old_name);
+    }
+    if config.networks.contains_key(new_name) {
+        anyhow::bail!("Network '{}' already exists", new_name);
+    }
+    if old_name == new_name {
+        anyhow::bail!("Old and new network names are the same");
+    }
+
+    let net_cfg = config
+        .networks
+        .remove(old_name)
+        .expect("network exists");
+    config.networks.insert(new_name.to_string(), net_cfg);
+
+    if config.network == old_name {
+        config.network = new_name.to_string();
+    }
+
+    for wallet in &mut config.wallets {
+        if wallet.network == old_name {
+            wallet.network = new_name.to_string();
+        }
+    }
+
     Ok(())
 }

--- a/src/utils/templates.rs
+++ b/src/utils/templates.rs
@@ -328,6 +328,101 @@ fn registry_path() -> Result<PathBuf> {
     Ok(dir.join("registry.json"))
 }
 
+/// Returns true if the path looks like a supported template archive.
+pub fn is_archive_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("zip"))
+        .unwrap_or(false)
+}
+
+/// Extract a `.zip` template package into `dest`, guarding against zip-slip paths.
+pub fn extract_zip_archive(archive: &Path, dest: &Path) -> Result<()> {
+    use zip::ZipArchive;
+
+    if !dest.exists() {
+        fs::create_dir_all(dest)?;
+    }
+
+    let file = fs::File::open(archive)
+        .with_context(|| format!("Failed to open archive {}", archive.display()))?;
+    let mut archive = ZipArchive::new(file)
+        .with_context(|| format!("Failed to read ZIP archive {}", archive.display()))?;
+
+    let dest_canon = dest
+        .canonicalize()
+        .unwrap_or_else(|_| dest.to_path_buf());
+
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i)?;
+        let entry_path = match entry.enclosed_name() {
+            Some(p) => p.to_path_buf(),
+            None => continue,
+        };
+
+        let out_path = dest_canon.join(&entry_path);
+        if !out_path.starts_with(&dest_canon) {
+            anyhow::bail!(
+                "Archive entry '{}' escapes the destination directory (zip-slip)",
+                entry_path.display()
+            );
+        }
+
+        if entry.name().ends_with('/') {
+            fs::create_dir_all(&out_path)?;
+        } else {
+            if let Some(parent) = out_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let mut outfile = fs::File::create(&out_path)?;
+            std::io::copy(&mut entry, &mut outfile)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// If `path` is a single top-level directory, return that directory; otherwise `path`.
+pub fn normalize_template_root(path: &Path) -> Result<PathBuf> {
+    if !path.is_dir() {
+        return Ok(path.to_path_buf());
+    }
+    let mut entries = fs::read_dir(path)?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            name != ".git" && name != "__MACOSX" && !name.to_string_lossy().starts_with('.')
+        })
+        .collect::<Vec<_>>();
+
+    entries.retain(|e| {
+        let n = e.file_name();
+        n != ".DS_Store"
+    });
+
+    if entries.len() == 1 && entries[0].path().is_dir() {
+        return Ok(entries[0].path());
+    }
+    Ok(path.to_path_buf())
+}
+
+/// Resolve a template path: directories are used as-is; ZIP archives are extracted to a temp dir.
+pub fn resolve_template_source(path: &Path) -> Result<(PathBuf, Option<tempfile::TempDir>)> {
+    if is_archive_path(path) {
+        let temp = tempfile::tempdir().context("Failed to create temp dir for archive extraction")?;
+        extract_zip_archive(path, temp.path())?;
+        let root = normalize_template_root(temp.path())?;
+        Ok((root, Some(temp)))
+    } else if path.is_dir() {
+        Ok((path.to_path_buf(), None))
+    } else {
+        anyhow::bail!(
+            "Template path must be a directory or .zip archive: {}",
+            path.display()
+        );
+    }
+}
+
 fn template_storage_dir() -> Result<PathBuf> {
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
     let dir = home.join(".starforge").join("templates").join("storage");
@@ -837,6 +932,29 @@ pub fn publish_template(
 }
 
 /// Like `publish_template` but also records optional CLI version constraints.
+/// Install a template from a directory or `.zip` archive into the local registry.
+pub fn install_template_package(
+    package_path: &Path,
+    name: String,
+    description: String,
+    author: String,
+    tags: Vec<String>,
+    version: String,
+    cli_version_min: Option<String>,
+    cli_version_max: Option<String>,
+) -> Result<()> {
+    publish_template_versioned(
+        package_path,
+        name,
+        description,
+        author,
+        tags,
+        version,
+        cli_version_min,
+        cli_version_max,
+    )
+}
+
 pub fn publish_template_versioned(
     template_path: &Path,
     name: String,
@@ -851,7 +969,9 @@ pub fn publish_template_versioned(
         anyhow::bail!("Template path does not exist: {}", template_path.display());
     }
 
-    validate_template_structure(template_path, &name, &description, &author, &version)?;
+    let (source_root, _temp_guard) = resolve_template_source(template_path)?;
+
+    validate_template_structure(&source_root, &name, &description, &author, &version)?;
 
     let dest = template_storage_dir()?.join(&name);
 
@@ -862,7 +982,7 @@ pub fn publish_template_versioned(
         );
     }
 
-    copy_dir_recursive(template_path, &dest)?;
+    copy_dir_recursive(&source_root, &dest)?;
 
     let entry = TemplateEntry {
         name: name.clone(),
@@ -880,7 +1000,7 @@ pub fn publish_template_versioned(
         updated_at: String::new(),
         cli_version_min,
         cli_version_max,
-        documented: template_path.join("README.md").exists(),
+        documented: source_root.join("README.md").exists(),
         maintenance: MaintenanceStatus::Active,
     };
 
@@ -981,6 +1101,60 @@ mod tests {
         )
         .unwrap();
         fs::write(dir.join("src/lib.rs"), "#![no_std]\n").unwrap();
+    }
+
+    #[test]
+    fn extract_zip_archive_and_validate() {
+        use zip::write::FileOptions;
+        use zip::ZipWriter;
+
+        let tmp = tempdir().unwrap();
+        let tpl_dir = tmp.path().join("inner");
+        make_valid_template(&tpl_dir);
+
+        let zip_path = tmp.path().join("package.zip");
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options = FileOptions::default();
+
+        for entry in walkdir_flat(&tpl_dir) {
+            let rel = entry.strip_prefix(&tpl_dir).unwrap();
+            let name = rel.to_string_lossy().replace('\\', "/");
+            if entry.is_dir() {
+                zip.add_directory(format!("{}/", name), options)
+                    .unwrap();
+            } else {
+                zip.start_file(name, options).unwrap();
+                let mut f = fs::File::open(entry).unwrap();
+                std::io::copy(&mut f, &mut zip).unwrap();
+            }
+        }
+        zip.finish().unwrap();
+
+        let extract_dir = tmp.path().join("out");
+        extract_zip_archive(&zip_path, &extract_dir).unwrap();
+        let root = normalize_template_root(&extract_dir).unwrap();
+        assert!(
+            validate_template_structure(&root, "zip-tpl", "desc", "author", "1.0.0").is_ok()
+        );
+    }
+
+    fn walkdir_flat(dir: &Path) -> Vec<PathBuf> {
+        let mut out = Vec::new();
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(d) = stack.pop() {
+            if d.is_dir() {
+                for entry in fs::read_dir(&d).unwrap() {
+                    let p = entry.unwrap().path();
+                    if p.is_dir() {
+                        stack.push(p);
+                    } else {
+                        out.push(p);
+                    }
+                }
+            }
+        }
+        out
     }
 
     #[test]

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -173,6 +173,77 @@ fn network_switch_unknown_network_fails() {
 }
 
 #[test]
+fn network_remove_custom_succeeds() {
+    let home = isolated_home();
+    starforge(home.path())
+        .args([
+            "network",
+            "add",
+            "removable-net",
+            "--horizon-url",
+            "https://example.com/horizon",
+        ])
+        .output()
+        .expect("spawn network add");
+
+    let output = starforge(home.path())
+        .args(["network", "remove", "removable-net"])
+        .output()
+        .expect("spawn network remove");
+    assert_success(&output, "starforge network remove");
+
+    let show = starforge(home.path())
+        .args(["network", "show"])
+        .output()
+        .expect("spawn network show");
+    let stdout = String::from_utf8_lossy(&show.stdout);
+    assert!(
+        !stdout.to_lowercase().contains("removable-net"),
+        "removed network should not appear in show output"
+    );
+}
+
+#[test]
+fn network_remove_reserved_fails() {
+    let home = isolated_home();
+    let output = starforge(home.path())
+        .args(["network", "remove", "testnet"])
+        .output()
+        .expect("spawn network remove testnet");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("built-in") || stderr.contains("cannot be removed"));
+}
+
+#[test]
+fn network_rename_custom_succeeds() {
+    let home = isolated_home();
+    starforge(home.path())
+        .args([
+            "network",
+            "add",
+            "old-net",
+            "--horizon-url",
+            "https://example.com/horizon",
+        ])
+        .output()
+        .expect("spawn network add");
+
+    let output = starforge(home.path())
+        .args(["network", "rename", "old-net", "new-net"])
+        .output()
+        .expect("spawn network rename");
+    assert_success(&output, "starforge network rename");
+
+    let show = starforge(home.path())
+        .args(["network", "show"])
+        .output()
+        .expect("spawn network show");
+    let stdout = String::from_utf8_lossy(&show.stdout);
+    assert!(stdout.to_lowercase().contains("new-net"));
+}
+
+#[test]
 fn network_add_reserved_name_fails() {
     let home = isolated_home();
     let output = starforge(home.path())


### PR DESCRIPTION
## Summary

This PR completes four CLI lifecycle improvements for networks, plugins, and templates.

- **#242** — Add `starforge network remove` and `starforge network rename` for custom networks, with built-in network protection and wallet/active-network updates.
- **#254** — Introduce `starforge-plugin.toml` manifest schema with required `starforge_version`, enforce compatibility at install/load time, and surface clear errors when a plugin targets the wrong CLI major version.
- **#252** — Support `.zip` template packages for `starforge template publish` and new `starforge template install`, including zip-slip-safe extraction and single-root normalization.
- **#257** — Improve `starforge plugin uninstall` with `--purge` / `--yes`, managed-path file deletion, in-use warnings, and best-effort plugin unload before registry removal.

Closes #242
Closes #254
Closes #252
Closes #257

## Changes

### Network management
- `remove_custom_network` / `rename_custom_network` in config layer
- CLI subcommands with reserved-name guards for `testnet`, `mainnet`, `docker-testnet`
- Smoke tests for remove, rename, and reserved-network failures

### Plugin system
- New `src/plugins/manifest.rs` with `PluginManifest` and compatibility validation
- Install requires manifest; registry stores `starforge_version` and `plugin_version`
- Loader checks manifest when present beside the library
- `plugin uninstall --purge --yes` with `registry::uninstall_plugin`

### Templates
- `zip` + `tempfile` dependencies
- `extract_zip_archive`, `resolve_template_source`, `template install` subcommand
- Unit test for ZIP extract + validation

## Test plan

- [x] `cargo build`
- [x] `cargo test --test cli_smoke network_`
- [x] `cargo test --bin starforge manifest`
- [x] `cargo test --bin starforge extract_zip`
- [ ] `starforge network remove` / `rename` on a custom network
- [ ] `starforge plugin install` with valid `starforge-plugin.toml`
- [ ] `starforge template publish` / `install` with a `.zip` package
- [ ] `starforge plugin uninstall <name> --purge --yes`