### PR TITLE
Version compatibility

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -219,7 +219,10 @@ fn scaffold_contract(
 
     p::header(&format!("Scaffolding Soroban contract: {}", name));
     println!("  Template: {}\n", template.cyan());
-
+    // Ensure selected template is compatible with current CLI version
+    let entry = templates::get_template(&template)?;
+    templates::assert_template_compatible(&entry)?;
+    
     // Roll back the partially-created directory if any step below fails.
     let mut target_guard = PathCleanup::new(dir.to_path_buf());
 

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -221,7 +221,30 @@ fn scaffold_contract(
     println!("  Template: {}\n", template.cyan());
     // Ensure selected template is compatible with current CLI version
     let entry = templates::get_template(&template)?;
-    templates::assert_template_compatible(&entry)?;
+    match templates::check_template_compatibility(&entry) {
+        templates::CompatibilityStatus::Compatible => {}
+        templates::CompatibilityStatus::TooOld { required_min, running } => {
+            p::error(&format!(
+                "Template '{}' requires StarForge >= {} but you are running {}.\nPlease upgrade StarForge: https://github.com/Nanle-code/StarForge#installation",
+                entry.name, required_min, running
+            ));
+            return Ok(());
+        }
+        templates::CompatibilityStatus::TooNew { required_max, running } => {
+            p::error(&format!(
+                "Template '{}' only supports StarForge <= {} but you are running {}.\nUse an older StarForge version or choose a compatible template.",
+                entry.name, required_max, running
+            ));
+            return Ok(());
+        }
+        templates::CompatibilityStatus::MalformedMetadata { reason } => {
+            p::error(&format!(
+                "Template '{}' has malformed version metadata: {}.\nContact the template author to fix the cli_version_min / cli_version_max fields.",
+                entry.name, reason
+            ));
+            return Ok(());
+        }
+    }
     
     // Roll back the partially-created directory if any step below fails.
     let mut target_guard = PathCleanup::new(dir.to_path_buf());


### PR DESCRIPTION
this pr closes #247 

# Pull Request: Add version compatibility checks for templates

## Summary
Implemented robust CLI version compatibility validation for template selection in `starforge new contract`. This prevents scaffolding projects with incompatible templates.

## Changes
- Updated `src/commands/new.rs` to replace strict compatibility assertion with detailed match handling.
- Added user‑friendly error messages for:
  - Template requires newer StarForge version.
  - Template does not support the current newer CLI version.
  - Malformed version metadata.
- Early exit on incompatibility to avoid partial scaffolding.

## Verification
- Manual testing of `starforge new contract` with templates requiring different version ranges confirms correct warnings.
- Existing functionality unchanged for compatible templates.

---
*Branch*: `master` (fork) tracking `fork/master`.
*Upstream*: `origin/master` (Nanle-code/StarForge).
