### PR TITLE
feat: wallet import --key, template info/install/update, commands tree

### DIFF
--- a/src/commands/command_tree.rs
+++ b/src/commands/command_tree.rs
@@ -1,0 +1,245 @@
+use crate::utils::print as p;
+use anyhow::Result;
+use colored::*;
+
+struct CmdEntry {
+    name: &'static str,
+    about: &'static str,
+    subs: &'static [(&'static str, &'static str)],
+}
+
+const COMMANDS: &[CmdEntry] = &[
+    CmdEntry {
+        name: "wallet",
+        about: "Manage test wallets (create, list, fund, show, remove)",
+        subs: &[
+            ("create", "Create a new keypair and save it locally"),
+            ("list", "List all saved wallets"),
+            (
+                "show",
+                "Show details of a saved wallet including live balance",
+            ),
+            ("fund", "Fund a wallet via a configured network faucet"),
+            ("remove", "Remove a wallet from local storage"),
+            ("rename", "Rename a wallet"),
+            (
+                "merge",
+                "Close a source account and send remaining XLM to a destination",
+            ),
+            (
+                "rotate",
+                "Rotate a wallet in place while keeping the same logical name",
+            ),
+            ("export", "Export a wallet to an encrypted JSON backup file"),
+            (
+                "import",
+                "Import a wallet from a backup file, BIP39 phrase, or raw secret key",
+            ),
+            (
+                "connect",
+                "Connect to a hardware wallet (Ledger/Trezor) and show device info",
+            ),
+            (
+                "hw-address",
+                "Show the Stellar address derived from a connected hardware wallet",
+            ),
+            (
+                "hw-status",
+                "Show connection status of a hardware wallet without full connect",
+            ),
+            (
+                "sign",
+                "Sign an arbitrary message using a local or hardware-backed key",
+            ),
+            ("multisig", "Multi-signature account management"),
+        ],
+    },
+    CmdEntry {
+        name: "template",
+        about: "Manage community contract templates from the marketplace",
+        subs: &[
+            ("search", "Search for templates in the marketplace"),
+            ("list", "List all available templates"),
+            ("show", "Show details of a specific template"),
+            (
+                "info",
+                "Show full metadata: author, license, repository, trust badges",
+            ),
+            (
+                "install",
+                "Install a template from a Git URL, local path, or registry name",
+            ),
+            (
+                "update",
+                "Update installed templates to their latest versions",
+            ),
+            ("publish", "Publish a template to the local marketplace"),
+            ("remove", "Remove a template from the local marketplace"),
+            (
+                "init",
+                "Initialize the template registry with example templates",
+            ),
+        ],
+    },
+    CmdEntry {
+        name: "new",
+        about: "Generate Soroban project boilerplate",
+        subs: &[
+            ("contract", "Scaffold a new Soroban smart contract"),
+            ("dapp", "Scaffold a new Soroban dapp"),
+        ],
+    },
+    CmdEntry {
+        name: "contract",
+        about: "Contract operations (invoke, inspect, etc.)",
+        subs: &[
+            ("invoke", "Invoke a deployed contract function"),
+            ("inspect", "Inspect a compiled contract .wasm file"),
+        ],
+    },
+    CmdEntry {
+        name: "deploy",
+        about: "Deploy a compiled Soroban contract (.wasm)",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "inspect",
+        about: "Deep contract storage inspection (state, key, storage)",
+        subs: &[
+            ("state", "Show all storage entries for a contract"),
+            ("key", "Show a specific storage key"),
+            ("storage", "Dump raw storage"),
+        ],
+    },
+    CmdEntry {
+        name: "network",
+        about: "View or switch the active network (testnet/mainnet)",
+        subs: &[
+            ("show", "Show the active network and its configuration"),
+            ("switch", "Switch the active network"),
+            ("add", "Add a custom network"),
+            ("remove", "Remove a custom network"),
+            ("configure", "Edit network configuration"),
+        ],
+    },
+    CmdEntry {
+        name: "node",
+        about: "Local Soroban devnet (Docker quickstart)",
+        subs: &[
+            ("start", "Start the local Soroban devnet via Docker"),
+            ("stop", "Stop the running devnet"),
+            ("status", "Check devnet status"),
+            ("logs", "Stream devnet container logs"),
+        ],
+    },
+    CmdEntry {
+        name: "tx",
+        about: "Fetch transaction details for an account",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "plugin",
+        about: "Manage third-party plugins",
+        subs: &[
+            ("install", "Install a plugin from a shared library path"),
+            ("list", "List all installed plugins"),
+            ("uninstall", "Remove an installed plugin"),
+            ("update", "Update a plugin to a newer version"),
+        ],
+    },
+    CmdEntry {
+        name: "shell",
+        about: "Interactive REPL for local Soroban contract testing",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "monitor",
+        about: "Live monitoring (contract events or wallet threshold)",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "tutorial",
+        about: "Interactive CLI tutorials",
+        subs: &[
+            ("list", "List available tutorials"),
+            ("start", "Start an interactive tutorial"),
+            ("reset", "Reset tutorial progress"),
+        ],
+    },
+    CmdEntry {
+        name: "benchmark",
+        about: "Performance benchmarking utilities",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "test",
+        about: "Contract testing utilities for Soroban wasm",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "gas",
+        about: "Gas analysis and optimization helpers",
+        subs: &[
+            ("estimate", "Estimate gas cost for a contract invocation"),
+            ("report", "Generate a gas usage report"),
+        ],
+    },
+    CmdEntry {
+        name: "upgrade",
+        about: "Contract upgrade management (propose, approve, execute, rollback)",
+        subs: &[
+            ("propose", "Propose a contract upgrade"),
+            ("approve", "Approve a pending upgrade"),
+            ("execute", "Execute an approved upgrade"),
+            ("rollback", "Roll back to the previous contract version"),
+        ],
+    },
+    CmdEntry {
+        name: "lint",
+        about: "Static analysis and linting for Soroban contracts",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "completions",
+        about: "Generate shell completions for bash, zsh, and fish",
+        subs: &[
+            ("bash", "Generate bash completions"),
+            ("zsh", "Generate zsh completions"),
+            ("fish", "Generate fish completions"),
+        ],
+    },
+    CmdEntry {
+        name: "info",
+        about: "Show starforge config and environment info",
+        subs: &[],
+    },
+    CmdEntry {
+        name: "commands",
+        about: "Display the full command tree (this command)",
+        subs: &[],
+    },
+];
+
+pub fn handle() -> Result<()> {
+    p::header("StarForge Command Tree");
+    println!();
+
+    for cmd in COMMANDS {
+        print!("  {:<16}", cmd.name.bold().cyan());
+        println!("{}", cmd.about.dimmed());
+
+        for (sub, desc) in cmd.subs {
+            print!("    {:<14}", sub.bold());
+            println!("{}", desc.dimmed());
+        }
+
+        if !cmd.subs.is_empty() {
+            println!();
+        }
+    }
+
+    println!();
+    p::info("Plugin-provided commands are shown after `starforge <plugin-name> --help`.");
+    p::info("Use `starforge <command> --help` for full flag documentation.");
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod benchmark;
+pub mod command_tree;
 pub mod completions;
 pub mod contract;
 pub mod deploy;

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -63,6 +63,34 @@ pub enum TemplateCommands {
     },
     /// Initialize the template registry with example templates
     Init,
+    /// Show full metadata for a template: author, version, license, repository, trust badges
+    Info {
+        /// Template name
+        name: String,
+    },
+    /// Install a template from a Git URL, local path, or marketplace registry name
+    Install {
+        /// Source: git URL (https://...), local filesystem path, or registry template name
+        source: String,
+        /// Override the installed template name (defaults to the template name or URL basename)
+        #[arg(long)]
+        name: Option<String>,
+        /// Pin to a specific version when installing from the marketplace registry
+        #[arg(long)]
+        version: Option<String>,
+        /// Overwrite the template if it is already installed
+        #[arg(long, default_value = "false")]
+        force: bool,
+    },
+    /// Update installed templates to their latest versions
+    Update {
+        /// Name of the template to update (omit when using --all)
+        #[arg(long, conflicts_with = "all")]
+        name: Option<String>,
+        /// Update all installed git-sourced templates
+        #[arg(long, short, conflicts_with = "name")]
+        all: bool,
+    },
 }
 
 pub fn handle(cmd: TemplateCommands) -> Result<()> {
@@ -97,6 +125,14 @@ pub fn handle(cmd: TemplateCommands) -> Result<()> {
         TemplateCommands::Show { name } => show(name),
         TemplateCommands::Remove { name } => remove(name),
         TemplateCommands::Init => init(),
+        TemplateCommands::Info { name } => info(name),
+        TemplateCommands::Install {
+            source,
+            name,
+            version,
+            force,
+        } => install(source, name, version, force),
+        TemplateCommands::Update { name, all } => update(name, all),
     }
 }
 
@@ -402,5 +438,177 @@ fn remove(name: String) -> Result<()> {
 
 fn init() -> Result<()> {
     p::info("Template registry is ready. Use `starforge template list` to view templates.");
+    Ok(())
+}
+
+fn info(name: String) -> Result<()> {
+    use crate::utils::templates::{check_template_compatibility, CompatibilityStatus};
+
+    let template = templates::get_template(&name)?;
+
+    p::header(&format!("Template Info: {}", template.name));
+    p::separator();
+
+    p::kv_accent("Name", &template.name);
+    p::kv("Version", &template.version);
+
+    if !template.author.is_empty() {
+        p::kv("Author", &template.author);
+    }
+    if !template.description.is_empty() {
+        p::kv("Description", &template.description);
+    }
+    if !template.tags.is_empty() {
+        p::kv("Tags", &template.tags.join(", "));
+    }
+
+    println!();
+    p::info("Source & Repository");
+    p::kv("Source", &template.source.to_string());
+    if let Some(ref repo) = template.repository_url {
+        p::kv("Repository", repo);
+    }
+
+    println!();
+    p::info("Licensing & Compatibility");
+    if let Some(ref license) = template.license {
+        p::kv("License", license);
+    } else {
+        p::kv("License", "Not declared");
+    }
+    match (
+        template.cli_version_min.as_deref(),
+        template.cli_version_max.as_deref(),
+    ) {
+        (Some(min), Some(max)) => p::kv("CLI Version Range", &format!(">= {}  <=  {}", min, max)),
+        (Some(min), None) => p::kv("CLI Version Range", &format!(">= {}", min)),
+        (None, Some(max)) => p::kv("CLI Version Range", &format!("<= {}", max)),
+        (None, None) => p::kv("CLI Version Range", "Any version"),
+    }
+    match check_template_compatibility(&template) {
+        CompatibilityStatus::Compatible => p::success("Compatible with this StarForge version"),
+        CompatibilityStatus::TooOld {
+            required_min,
+            running,
+        } => p::warn(&format!(
+            "Incompatible: requires >= {} (running {})",
+            required_min, running
+        )),
+        CompatibilityStatus::TooNew {
+            required_max,
+            running,
+        } => p::warn(&format!(
+            "Incompatible: requires <= {} (running {})",
+            required_max, running
+        )),
+        CompatibilityStatus::MalformedMetadata { reason } => {
+            p::warn(&format!("Malformed version metadata: {}", reason))
+        }
+    }
+
+    println!();
+    p::info("Quality & Trust");
+    p::kv(
+        "Quality Score",
+        &format!("{}/100", template.quality_score()),
+    );
+    p::kv("Maintenance", template.maintenance.label());
+    p::kv(
+        "Documentation",
+        if template.documented {
+            "Available"
+        } else {
+            "Not provided"
+        },
+    );
+    p::kv("Downloads", &template.downloads.to_string());
+
+    let badges = template.trust_indicators();
+    if !badges.is_empty() {
+        p::kv("Trust Badges", &badges.join("  "));
+    }
+
+    if !template.created_at.is_empty() {
+        println!();
+        p::info("Timestamps");
+        p::kv("Published", &template.created_at);
+        if !template.updated_at.is_empty() {
+            p::kv("Last Updated", &template.updated_at);
+        }
+    }
+
+    p::separator();
+    Ok(())
+}
+
+fn install(
+    source: String,
+    name: Option<String>,
+    version: Option<String>,
+    force: bool,
+) -> Result<()> {
+    p::header("Template Install");
+    p::kv("Source", &source);
+    if let Some(ref n) = name {
+        p::kv("Name override", n);
+    }
+    if let Some(ref v) = version {
+        p::kv("Version", v);
+    }
+    println!();
+
+    p::step(1, 2, "Resolving and fetching template...");
+    let entry = templates::install_template(&source, name.as_deref(), version.as_deref(), force)?;
+
+    p::step(2, 2, "Registering in local registry...");
+    println!();
+    p::success(&format!("Template '{}' installed", entry.name));
+    p::kv_accent("Name", &entry.name);
+    p::kv("Version", &entry.version);
+    p::kv("Source", &entry.source.to_string());
+    if let Some(ref path) = entry.path {
+        p::kv("Local path", path);
+    }
+    p::info(&format!(
+        "Use it with: starforge template info {}",
+        entry.name
+    ));
+    Ok(())
+}
+
+fn update(name: Option<String>, all: bool) -> Result<()> {
+    if all {
+        p::header("Template Update — All");
+        p::step(1, 1, "Updating all git-sourced templates...");
+        let results = templates::update_all_installed_templates()?;
+
+        if results.is_empty() {
+            p::info("No git-sourced templates are installed.");
+            return Ok(());
+        }
+
+        println!();
+        for (tpl_name, result) in &results {
+            match result {
+                Ok(()) => p::success(&format!("  {} updated", tpl_name)),
+                Err(e) => p::warn(&format!("  {} — {}", tpl_name, e)),
+            }
+        }
+
+        let ok = results.iter().filter(|(_, r)| r.is_ok()).count();
+        println!();
+        p::kv("Updated", &format!("{}/{}", ok, results.len()));
+        return Ok(());
+    }
+
+    let name = name.ok_or_else(|| {
+        anyhow::anyhow!("Provide a template name or --all to update all templates")
+    })?;
+
+    p::header(&format!("Template Update: {}", name));
+    p::step(1, 1, "Re-fetching from source...");
+    templates::update_installed_template(&name)?;
+    println!();
+    p::success(&format!("Template '{}' updated", name));
     Ok(())
 }

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -152,9 +152,9 @@ pub enum WalletCommands {
         #[arg(long)]
         output: PathBuf,
     },
-    /// Import a wallet from a JSON backup or BIP39 recovery phrase
+    /// Import a wallet from a JSON backup, BIP39 recovery phrase, or raw Stellar secret key
     Import {
-        /// Wallet name (required with --mnemonic)
+        /// Wallet name (required with --mnemonic or --key)
         name: Option<String>,
         /// Path to backup JSON file
         #[arg(long, group = "source")]
@@ -162,6 +162,9 @@ pub enum WalletCommands {
         /// Import from a BIP39 recovery phrase (prompted interactively)
         #[arg(long, group = "source")]
         mnemonic: bool,
+        /// Import from a raw Stellar secret key (starts with 'S', 56 characters)
+        #[arg(long, group = "source")]
+        key: Option<String>,
         /// Account index for SEP-0005 path m/44'/148'/index'
         #[arg(long, default_value = "0")]
         account_index: u32,
@@ -312,10 +315,19 @@ pub fn handle(cmd: WalletCommands) -> Result<()> {
             name,
             file,
             mnemonic: from_mnemonic,
+            key,
             account_index,
             network,
             encrypt,
-        } => import_wallet(name, file, from_mnemonic, account_index, network, encrypt),
+        } => import_wallet(
+            name,
+            file,
+            from_mnemonic,
+            key,
+            account_index,
+            network,
+            encrypt,
+        ),
         WalletCommands::Connect { device } => connect_hardware(device),
         WalletCommands::HwAddress { device, path } => hw_address(device, &path),
         WalletCommands::HwStatus { device } => hw_status(device),
@@ -1119,6 +1131,7 @@ fn import_wallet(
     name: Option<String>,
     file: Option<PathBuf>,
     from_mnemonic: bool,
+    key: Option<String>,
     account_index: u32,
     network_override: Option<String>,
     encrypt: bool,
@@ -1130,8 +1143,19 @@ fn import_wallet(
         return import_from_mnemonic(name, account_index, network_override, encrypt);
     }
 
+    if let Some(secret_key) = key {
+        let name = name.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Wallet name is required when using --key (e.g. starforge wallet import alice --key SXXX...)"
+            )
+        })?;
+        return import_from_secret_key(name, secret_key, network_override, encrypt);
+    }
+
     let file = file.ok_or_else(|| {
-        anyhow::anyhow!("Provide --file <backup.json> or --mnemonic to import a wallet")
+        anyhow::anyhow!(
+            "Provide --file <backup.json>, --mnemonic, or --key <SXXX...> to import a wallet"
+        )
     })?;
     import_wallets(file)
 }
@@ -1178,6 +1202,64 @@ fn import_from_mnemonic(
 
     config::save(&cfg)?;
     p::success(&format!("Wallet '{}' imported from recovery phrase", name));
+    p::info(&format!(
+        "View it with: {}",
+        format!("starforge wallet show {}", name).cyan()
+    ));
+    Ok(())
+}
+
+fn import_from_secret_key(
+    name: String,
+    secret_key: String,
+    network_override: Option<String>,
+    encrypt: bool,
+) -> Result<()> {
+    if secret_key.contains(':') {
+        anyhow::bail!(
+            "--key expects a raw Stellar secret key (starts with 'S', 56 characters), \
+             not an encrypted bundle. Use --file to import an encrypted backup."
+        );
+    }
+    config::validate_secret_key(&secret_key)?;
+
+    let mut cfg = config::load()?;
+    config::validate_wallet_name(&name)?;
+
+    if cfg.wallets.iter().any(|w| w.name == name) {
+        anyhow::bail!("A wallet named '{}' already exists.", name);
+    }
+
+    let decoded_secret = StellarPrivateKey::from_string(&secret_key)
+        .map_err(|_| anyhow::anyhow!("Invalid Stellar secret key format"))?;
+    let signing_key = SigningKey::from_bytes(&decoded_secret.0);
+    let public_key = StellarPublicKey(signing_key.verifying_key().to_bytes()).to_string();
+
+    let network = network_override.unwrap_or_else(|| cfg.network.clone());
+
+    p::header(&format!("Importing wallet '{}' from secret key", name));
+    p::kv_accent("Public Key", &public_key);
+
+    let secret_to_store = if encrypt {
+        println!();
+        let pwd = crypto::prompt_passphrase("Set a passphrase to encrypt this wallet", false)?;
+        crypto::encrypt_secret(&pwd, &secret_key, None)?
+    } else {
+        secret_key
+    };
+
+    cfg.wallets.push(config::WalletEntry {
+        name: name.clone(),
+        public_key,
+        secret_key: Some(secret_to_store),
+        network,
+        created_at: Utc::now().to_rfc3339(),
+        funded: false,
+        rotation_history: Vec::new(),
+    });
+
+    config::save(&cfg)?;
+    p::success(&format!("Wallet '{}' imported from secret key", name));
     p::info(&format!(
         "View it with: {}",
         format!("starforge wallet show {}", name).cyan()

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,10 @@ enum Commands {
     /// Static analysis and linting for Soroban contracts
     Lint(commands::lint::LintArgs),
 
+    /// Display the full command tree (all top-level commands, subcommands, and plugin extensions)
+    #[command(name = "commands")]
+    CommandTree,
+
     /// Execute an installed plugin command (e.g. `starforge defi ...`)
     #[command(external_subcommand)]
     External(Vec<String>),
@@ -143,6 +147,7 @@ fn main() {
         Commands::Template(_) => "template",
         Commands::Upgrade(_) => "upgrade",
         Commands::Lint(_) => "lint",
+        Commands::CommandTree => "commands",
         Commands::External(_) => "external",
     }
     .to_string();
@@ -169,6 +174,7 @@ fn main() {
         Commands::Template(args) => commands::template::handle(args),
         Commands::Upgrade(cmd) => commands::upgrade::handle(cmd),
         Commands::Lint(args) => commands::lint::handle(args),
+        Commands::CommandTree => commands::command_tree::handle(),
         Commands::External(args) => handle_external_plugin(args),
     };
     let duration = start.elapsed();

--- a/src/utils/templates.rs
+++ b/src/utils/templates.rs
@@ -108,6 +108,12 @@ pub struct TemplateEntry {
     /// Declared maintenance state of the template.
     #[serde(default)]
     pub maintenance: MaintenanceStatus,
+    /// SPDX license identifier (e.g. "MIT", "Apache-2.0"). `None` if not declared.
+    #[serde(default)]
+    pub license: Option<String>,
+    /// URL of the template's source repository (e.g. GitHub link).
+    #[serde(default)]
+    pub repository_url: Option<String>,
 }
 
 /// Outcome of a template-vs-CLI compatibility check.
@@ -882,6 +888,8 @@ pub fn publish_template_versioned(
         cli_version_max,
         documented: template_path.join("README.md").exists(),
         maintenance: MaintenanceStatus::Active,
+        license: None,
+        repository_url: None,
     };
 
     add_template(entry)?;
@@ -943,6 +951,253 @@ pub fn validate_template_structure(
     Ok(())
 }
 
+/// Determine how to fetch a template from a user-supplied source string,
+/// then register it in the local registry and return the new entry.
+///
+/// Source resolution order:
+/// 1. Starts with `https://`, `http://`, `git://`, or ends with `.git` → git URL
+/// 2. Path exists on disk, or starts with `/`, `./`, or `../` → local path
+/// 3. Anything else → treated as a registry template name (marketplace lookup)
+pub fn install_template(
+    source: &str,
+    name_override: Option<&str>,
+    version: Option<&str>,
+    force: bool,
+) -> Result<TemplateEntry> {
+    if source.starts_with("https://")
+        || source.starts_with("http://")
+        || source.starts_with("git://")
+        || source.ends_with(".git")
+    {
+        return install_from_git_url(source, name_override, force);
+    }
+
+    let path = Path::new(source);
+    if path.exists()
+        || source.starts_with('/')
+        || source.starts_with("./")
+        || source.starts_with("../")
+    {
+        return install_from_local_path(path, name_override, force);
+    }
+
+    install_from_registry(source, version, force)
+}
+
+fn install_from_git_url(
+    url: &str,
+    name_override: Option<&str>,
+    force: bool,
+) -> Result<TemplateEntry> {
+    let name = name_override.map(str::to_string).unwrap_or_else(|| {
+        url.trim_end_matches('/')
+            .rsplit('/')
+            .next()
+            .unwrap_or("template")
+            .trim_end_matches(".git")
+            .to_string()
+    });
+
+    let mut registry = load_registry()?;
+    if registry.templates.iter().any(|t| t.name == name) && !force {
+        anyhow::bail!(
+            "Template '{}' is already installed. Use --force to overwrite.",
+            name
+        );
+    }
+
+    let dest = template_storage_dir()?.join(&name);
+    if dest.exists() {
+        fs::remove_dir_all(&dest).with_context(|| {
+            format!(
+                "Failed to remove existing template directory {}",
+                dest.display()
+            )
+        })?;
+    }
+
+    fetch_git_template(url, None, &dest)?;
+
+    let entry = TemplateEntry {
+        name: name.clone(),
+        description: String::new(),
+        version: "1.0.0".to_string(),
+        source: TemplateSource::Git {
+            url: url.to_string(),
+            branch: None,
+        },
+        tags: vec![],
+        path: Some(dest.to_string_lossy().to_string()),
+        author: String::new(),
+        downloads: 0,
+        verified: false,
+        created_at: String::new(),
+        updated_at: String::new(),
+        cli_version_min: None,
+        cli_version_max: None,
+        documented: dest.join("README.md").exists(),
+        maintenance: MaintenanceStatus::Unknown,
+        license: None,
+        repository_url: Some(url.to_string()),
+    };
+
+    registry.templates.retain(|t| t.name != name);
+    registry.templates.push(entry.clone());
+    save_registry(&registry)?;
+
+    Ok(entry)
+}
+
+fn install_from_local_path(
+    path: &Path,
+    name_override: Option<&str>,
+    force: bool,
+) -> Result<TemplateEntry> {
+    if !path.exists() {
+        anyhow::bail!("Local path does not exist: {}", path.display());
+    }
+
+    let name = name_override.map(str::to_string).unwrap_or_else(|| {
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("template")
+            .to_string()
+    });
+
+    let mut registry = load_registry()?;
+    if registry.templates.iter().any(|t| t.name == name) && !force {
+        anyhow::bail!(
+            "Template '{}' is already installed. Use --force to overwrite.",
+            name
+        );
+    }
+
+    let dest = template_storage_dir()?.join(&name);
+    if dest.exists() {
+        fs::remove_dir_all(&dest).with_context(|| {
+            format!(
+                "Failed to remove existing template directory {}",
+                dest.display()
+            )
+        })?;
+    }
+
+    fetch_local_template(path, &dest)?;
+
+    let entry = TemplateEntry {
+        name: name.clone(),
+        description: String::new(),
+        version: "1.0.0".to_string(),
+        source: TemplateSource::Local {
+            path: dest.to_string_lossy().to_string(),
+        },
+        tags: vec![],
+        path: Some(dest.to_string_lossy().to_string()),
+        author: String::new(),
+        downloads: 0,
+        verified: false,
+        created_at: String::new(),
+        updated_at: String::new(),
+        cli_version_min: None,
+        cli_version_max: None,
+        documented: dest.join("README.md").exists(),
+        maintenance: MaintenanceStatus::Unknown,
+        license: None,
+        repository_url: None,
+    };
+
+    registry.templates.retain(|t| t.name != name);
+    registry.templates.push(entry.clone());
+    save_registry(&registry)?;
+
+    Ok(entry)
+}
+
+fn install_from_registry(name: &str, version: Option<&str>, force: bool) -> Result<TemplateEntry> {
+    let entry = get_template_by_name_and_version(name, version)?;
+    assert_template_compatible(&entry)?;
+
+    let dest = template_storage_dir()?.join(&entry.name);
+    if dest.exists() {
+        if !force {
+            anyhow::bail!(
+                "Template '{}' is already cached locally. Use --force to re-download.",
+                entry.name
+            );
+        }
+        fs::remove_dir_all(&dest)
+            .with_context(|| format!("Failed to remove cached template at {}", dest.display()))?;
+    }
+
+    match &entry.source {
+        TemplateSource::Git { url, branch } => fetch_git_template(url, branch.as_deref(), &dest)?,
+        TemplateSource::Local { path: src_path } => {
+            fetch_local_template(Path::new(src_path), &dest)?
+        }
+        TemplateSource::Builtin { id } => fetch_builtin_template(id, &dest)?,
+    }
+
+    Ok(entry)
+}
+
+/// Re-fetch a git-sourced template into its local storage directory, updating
+/// it in place. Only git-sourced templates support this operation.
+pub fn update_installed_template(name: &str) -> Result<()> {
+    let entry = get_template(name)?;
+
+    match &entry.source {
+        TemplateSource::Git { url, branch } => {
+            let dest = if let Some(ref p) = entry.path {
+                PathBuf::from(p)
+            } else {
+                template_storage_dir()?.join(name)
+            };
+
+            if dest.exists() {
+                fs::remove_dir_all(&dest).with_context(|| {
+                    format!("Failed to remove existing template at {}", dest.display())
+                })?;
+            }
+
+            fetch_git_template(url, branch.as_deref(), &dest)?;
+
+            let mut registry = load_registry()?;
+            if let Some(t) = registry.templates.iter_mut().find(|t| t.name == name) {
+                t.path = Some(dest.to_string_lossy().to_string());
+                t.updated_at = String::new();
+            }
+            save_registry(&registry)?;
+
+            Ok(())
+        }
+        other => anyhow::bail!(
+            "Template '{}' uses source '{}' which does not support updates. \
+             Only git-sourced templates can be updated.",
+            name,
+            other
+        ),
+    }
+}
+
+/// Update all git-sourced templates. Returns a list of (name, result) pairs.
+pub fn update_all_installed_templates() -> Result<Vec<(String, Result<()>)>> {
+    let registry = load_registry()?;
+    let git_names: Vec<String> = registry
+        .templates
+        .iter()
+        .filter(|t| matches!(t.source, TemplateSource::Git { .. }))
+        .map(|t| t.name.clone())
+        .collect();
+
+    Ok(git_names
+        .into_iter()
+        .map(|name| {
+            let result = update_installed_template(&name);
+            (name, result)
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -967,6 +1222,8 @@ mod tests {
             cli_version_max: None,
             documented: false,
             maintenance: MaintenanceStatus::Unknown,
+            license: None,
+            repository_url: None,
         }
     }
 
@@ -1072,6 +1329,8 @@ mod tests {
             cli_version_max: None,
             documented: true,
             maintenance: MaintenanceStatus::Active,
+            license: None,
+            repository_url: None,
         });
 
         // Test name search
@@ -1117,6 +1376,8 @@ mod tests {
             cli_version_max: None,
             documented: false,
             maintenance: MaintenanceStatus::Unknown,
+            license: None,
+            repository_url: None,
         };
 
         let dest = tmp.path().join(&entry.name);
@@ -1164,6 +1425,8 @@ mod tests {
             cli_version_max: None,
             documented: false,
             maintenance: MaintenanceStatus::Unknown,
+            license: None,
+            repository_url: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Implements four features across the wallet and template subsystems:

- **#241** — `starforge wallet import --key <SXXX...>` accepts a raw Stellar Ed25519 secret key as an import source, derives the public key automatically, and optionally encrypts the secret at rest.
- **#244** — `starforge template info <name>` displays the full template metadata record: author, version, license, repository URL, CLI compatibility range, maintenance status, documentation availability, quality score, and trust badges. Adds `license` and `repository_url` optional fields to `TemplateEntry` (backwards-compatible via `#[serde(default)]`).
- **#243** — `starforge template install <source>` installs a template from a git URL, local path, or marketplace registry name. `starforge template update [--name <n> | --all]` re-fetches and refreshes git-sourced templates.
- **#246** — `starforge commands` prints the complete command tree — every top-level command, its subcommands, and brief descriptions — improving discoverability for new users.

## Files Changed

| File | Change |
|---|---|
| `src/commands/wallet.rs` | Add `--key` to `Import` variant + `import_from_secret_key()` |
| `src/commands/template.rs` | Add `Info`, `Install`, `Update` subcommands + handlers |
| `src/utils/templates.rs` | Add `license`, `repository_url` fields; add `install_template()`, `update_installed_template()`, `update_all_installed_templates()` |
| `src/commands/command_tree.rs` | New file — `starforge commands` handler |
| `src/commands/mod.rs` | Register `command_tree` module |
| `src/main.rs` | Register `CommandTree` variant |

## Test plan

- [x] `cargo build --locked` — clean build
- [x] `cargo test --locked` — all unit and integration tests pass
- [x] `cargo clippy --locked -- -D warnings` — zero warnings
- [x] `cargo fmt --all --check` — formatting verified
- [x] `cargo test --test cli_smoke --locked` — all 12 smoke tests pass

Closes #241
Closes #243
Closes #244
Closes #246