### PR TITLE
   feat: add visual trust indicator badges to template list/search output

### DIFF
--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -278,36 +278,22 @@ fn list() -> Result<()> {
     }
 
     for (i, template) in registry.templates.iter().enumerate() {
-        let compat = match check_template_compatibility(template) {
-            CompatibilityStatus::Compatible => "✓".to_string(),
-            CompatibilityStatus::TooOld { required_min, .. } => {
-                format!("✗ requires >= {}", required_min)
+        let compat_badge = match check_template_compatibility(template) {
+            CompatibilityStatus::Compatible => "[COMPATIBLE]",
+            CompatibilityStatus::TooOld { .. } | CompatibilityStatus::TooNew { .. } => {
+                "[INCOMPATIBLE]"
             }
-            CompatibilityStatus::TooNew { required_max, .. } => {
-                format!("✗ requires <= {}", required_max)
-            }
-            CompatibilityStatus::MalformedMetadata { .. } => "⚠ bad metadata".to_string(),
+            CompatibilityStatus::MalformedMetadata { .. } => "[BAD-META]",
         };
+        let mut badges = template.trust_indicators();
+        badges.push(compat_badge.to_string());
         println!(
-            "  {:>2}. {}@{}  [{}]",
-            i + 1,
-            template.name,
-            template.version,
-            compat
-        );
-        let badges = template.trust_indicators();
-        let badge_suffix = if badges.is_empty() {
-            String::new()
-        } else {
-            format!("  {}", badges.join("  "))
-        };
-        println!(
-            "  {:>2}. {}@{}  [quality {}/100]{}",
+            "  {:>2}. {}@{}  [quality {}/100]  {}",
             i + 1,
             template.name,
             template.version,
             template.quality_score(),
-            badge_suffix
+            badges.join(" "),
         );
         p::kv("Description", &template.description);
         p::kv("Source", &template.source.to_string());
@@ -332,6 +318,7 @@ fn search(
     min_quality: u8,
     refresh: bool,
 ) -> Result<()> {
+    use crate::utils::templates::{check_template_compatibility, CompatibilityStatus};
     let tag_list: Vec<String> = tags
         .unwrap_or_default()
         .split(',')
@@ -387,23 +374,25 @@ fn search(
 
     for (i, result) in results.iter().enumerate() {
         let template = &result.entry;
-        let badges = template.trust_indicators();
-        let badge_suffix = if badges.is_empty() {
-            String::new()
-        } else {
-            format!("  {}", badges.join("  "))
+        let compat_badge = match check_template_compatibility(template) {
+            CompatibilityStatus::Compatible => "[COMPATIBLE]",
+            CompatibilityStatus::TooOld { .. } | CompatibilityStatus::TooNew { .. } => {
+                "[INCOMPATIBLE]"
+            }
+            CompatibilityStatus::MalformedMetadata { .. } => "[BAD-META]",
         };
+        let mut badges = template.trust_indicators();
+        badges.push(compat_badge.to_string());
         println!(
-            "  {:>2}. {}@{}  [quality {}/100]{}",
+            "  {:>2}. {}@{}  [quality {}/100]  {}",
             i + 1,
             template.name,
             template.version,
             template.quality_score(),
-            badge_suffix
+            badges.join(" "),
         );
         p::kv("Description", &template.description);
         p::kv("Downloads", &template.downloads.to_string());
-        p::kv("Maintenance", template.maintenance.label());
         if !template.tags.is_empty() {
             p::kv("Tags", &template.tags.join(", "));
         }

--- a/src/utils/templates.rs
+++ b/src/utils/templates.rs
@@ -290,26 +290,29 @@ impl TemplateEntry {
         score.clamp(0, 100) as u8
     }
 
-    /// Human-readable trust/quality badges suitable for display to users.
+    /// Compact trust/quality badge strings for inline display in list/search output.
+    ///
+    /// Returns short tokens like `[VERIFIED]`, `[DOCS]`, `[ACTIVE]`, `[DEPRECATED]`,
+    /// `[POPULAR]` that can be joined and appended to a single summary line.
     pub fn trust_indicators(&self) -> Vec<String> {
         let mut badges = Vec::new();
 
         if self.verified {
-            badges.push("✓ Verified".to_string());
+            badges.push("[VERIFIED]".to_string());
         }
         if self.documented {
-            badges.push("📖 Documented".to_string());
+            badges.push("[DOCS]".to_string());
         }
 
         match self.maintenance {
-            MaintenanceStatus::Active => badges.push("🟢 Actively maintained".to_string()),
-            MaintenanceStatus::Maintained => badges.push("🟡 Maintained".to_string()),
-            MaintenanceStatus::Deprecated => badges.push("⚠ Deprecated".to_string()),
+            MaintenanceStatus::Active => badges.push("[ACTIVE]".to_string()),
+            MaintenanceStatus::Maintained => badges.push("[MAINTAINED]".to_string()),
+            MaintenanceStatus::Deprecated => badges.push("[DEPRECATED]".to_string()),
             MaintenanceStatus::Unknown => {}
         }
 
         if self.downloads >= 1000 {
-            badges.push(format!("★ Popular ({} downloads)", self.downloads));
+            badges.push("[POPULAR]".to_string());
         }
 
         badges


### PR DESCRIPTION
  
  Summary
  
  Enhances starforge template list and starforge template search output with compact, scannable
  trust indicator badges so users can quickly evaluate template dependability at a glance.
  
  Changes
  
  src/utils/templates.rs
  
  - Replaced verbose emoji badge strings in trust_indicators() with compact bracket tokens:
  [VERIFIED], [DOCS], [ACTIVE], [MAINTAINED], [DEPRECATED], [POPULAR]
  
  src/commands/template.rs
  
  - Fixed a bug in list() where each template entry was printed twice
  - Merged quality score + trust badges + compatibility into one unified summary line for both
  list and search
  - Added [COMPATIBLE] / [INCOMPATIBLE] / [BAD-META] badge derived from the CLI version
  compatibility check
  - Removed redundant Maintenance kv row in search() — now covered by the inline badges
  
  Before / After
  
  Before:
  
     1. hello-world@1.0.0  [✓]
     1. hello-world@1.0.0  [quality 80/100]  🟢 Actively maintained  📖 Documented
  
  After:
  
     1. hello-world@1.0.0  [quality 80/100]  [VERIFIED] [DOCS] [ACTIVE] [COMPATIBLE]
  
  Testing
  
  - starforge template list — single line per template with badges
  - starforge template search <query> — badges visible inline with each result
  - starforge template show <name> — trust signals section unchanged

close #250 