### PR TITLE
feat: add template cache expiration with 24h TTL and offline fallback

### DIFF
--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -192,7 +192,7 @@ pub fn handle(cmd: TemplateCommands) -> Result<()> {
             refresh,
         } => search(query, tags, verified, min_quality, refresh),
         TemplateCommands::Show { name } => show(name),
-        TemplateCommands::Remove { name } => remove(name),
+        TemplateCommands::Remove { name, purge } => remove(name, purge),
         TemplateCommands::Init => init(),
         TemplateCommands::Info { name } => info(name),
         TemplateCommands::Install {
@@ -202,8 +202,6 @@ pub fn handle(cmd: TemplateCommands) -> Result<()> {
             force,
         } => install(source, name, version, force),
         TemplateCommands::Update { name, all } => update(name, all),
-        // In the match arm
-TemplateCommands::Remove { name, purge } => remove(name, purge),
     }
 }
 

--- a/src/utils/templates.rs
+++ b/src/utils/templates.rs
@@ -463,17 +463,55 @@ pub fn fetch_template_cached(entry: &TemplateEntry, force_refresh: bool) -> Resu
     let dest = cache_root.join(&entry.name);
 
     if dest.exists() {
-        if force_refresh {
-            fs::remove_dir_all(&dest).with_context(|| {
-                format!("Failed to remove cached template at {}", dest.display())
-            })?;
+        let mut should_refresh = force_refresh;
+        if !should_refresh {
+            if let Ok(metadata) = fs::metadata(&dest) {
+                if let Ok(modified) = metadata.modified() {
+                    use std::time::{Duration, SystemTime};
+                    let ttl = Duration::from_secs(24 * 60 * 60); // 24 hours TTL
+                    if SystemTime::now()
+                        .duration_since(modified)
+                        .unwrap_or_else(|_| ttl)
+                        >= ttl
+                    {
+                        should_refresh = true;
+                    }
+                }
+            }
+        }
+
+        if should_refresh {
+            // Rename existing cache to a temporary name to preserve it in case refresh fails
+            let temp_old = cache_root.join(format!("{}.old", entry.name));
+            // Remove any existing temp_old directory
+            if temp_old.exists() {
+                fs::remove_dir_all(&temp_old)?;
+            }
+            fs::rename(&dest, &temp_old)?;
+            
+            // Try to fetch new template
+            match fetch_template(entry, &dest) {
+                Ok(_) => {
+                    // Success - clean up the old temp directory
+                    fs::remove_dir_all(&temp_old).ok(); // Ignore errors during cleanup
+                    Ok(dest)
+                }
+                Err(_) => {
+                    // Failed - restore old cache and use it
+                    if dest.exists() {
+                        fs::remove_dir_all(&dest)?;
+                    }
+                    fs::rename(&temp_old, &dest)?;
+                    Ok(dest)
+                }
+            }
         } else {
             return Ok(dest);
         }
+    } else {
+        fetch_template(entry, &dest)?;
+        Ok(dest)
     }
-
-    fetch_template(entry, &dest)?;
-    Ok(dest)
 }
 
 /// Return the `src/lib.rs` content for a marketplace template, fetching and


### PR DESCRIPTION
### Summary
This PR implements cache expiration for local template registry data with TTL-based freshness checks, plus offline fallback behavior. It also fixes a small duplicate match arm in template command handling.

### Changes Made
1. Fixed Duplicate Match Arm : Removed extra TemplateCommands::Remove arm in src/commands/template.rs that was missing the purge field, leaving only the correct one.
2. Template Cache Expiration (24h TTL) :
   
   - Added TTL (time-to-live) check in fetch_template_cached in src/utils/templates.rs
   - Uses 24-hour duration for cache freshness based on last modified timestamp
   - Automatically attempts to refresh from remote source when cache is stale
   - Preserves offline fallback: if refreshing fails (no network, etc.), it restores the existing cache and uses it instead of failing
3. Improved Refresh Safety :
   
   - When refreshing a stale or force-refreshed cache, we rename the existing cache to a temporary name first
   - If fetching new template data succeeds, the old temporary cache is cleaned up
   - If fetching fails, the old cache is restored, ensuring users can still work offline
### Testing
The changes maintain backwards compatibility and add safety measures for offline scenarios.

Closes #249 