### PR TITLE
feat(tutorials): add deploy tutorial

### DIFF
--- a/tutorials/deploy/README.md
+++ b/tutorials/deploy/README.md
@@ -1,0 +1,27 @@
+# Deploy a Soroban Contract
+
+Structured tutorial for building, uploading, and instantiating your first Soroban smart contract on Stellar testnet with StarForge.
+
+## Milestones
+
+1. **Balance check** — confirm your deployer wallet has enough XLM for fees
+2. **Build** — compile your contract to WASM with Stellar CLI
+3. **Simulate** — dry-run to validate size, fees, and output before broadcasting
+4. **Upload** — push the WASM to the Stellar network and record the contract hash
+5. **Verify** — confirm the deployment appears in your local deploy history
+
+## Prerequisites
+
+- Completed the [hello-world](../hello-world/README.md) tutorial (wallet created and funded)
+- A Soroban contract project in your current directory
+- Stellar CLI installed (`stellar --version`)
+
+## Interactive flow
+
+```bash
+starforge tutorial start deploy
+starforge tutorial next    # after each milestone
+starforge tutorial status
+```
+
+Step definitions live in `tutorial.json` beside this README.

--- a/tutorials/deploy/tutorial.json
+++ b/tutorials/deploy/tutorial.json
@@ -1,0 +1,32 @@
+{
+  "slug": "deploy",
+  "title": "Deploy a Soroban Contract",
+  "description": "Build, upload, and instantiate a Soroban smart contract on Stellar testnet using StarForge.",
+  "steps": [
+    {
+      "title": "Check your wallet balance",
+      "description": "Confirm your deployer wallet has enough XLM to cover upload and instantiation fees.",
+      "command": "starforge wallet balance deployer"
+    },
+    {
+      "title": "Build the contract",
+      "description": "Compile your Soroban contract to WASM. Run this from your contract project directory.",
+      "command": "stellar contract build"
+    },
+    {
+      "title": "Validate the WASM",
+      "description": "Run a dry-run deploy to check WASM size, fees, and that the contract compiles correctly — nothing is broadcast yet.",
+      "command": "starforge deploy --wasm target/wasm32v1-none/release/<your_contract>.wasm --wallet deployer --simulate"
+    },
+    {
+      "title": "Upload the contract",
+      "description": "Upload the compiled WASM to the Stellar network. This registers the contract code and returns a WASM hash.",
+      "command": "starforge deploy --wasm target/wasm32v1-none/release/<your_contract>.wasm --wallet deployer"
+    },
+    {
+      "title": "Verify on-chain",
+      "description": "Confirm the deployment succeeded by listing your recent deployments.",
+      "command": "starforge deploy list"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #126
Closes #395
Closes #396
Closes #401

## What was done

Added `tutorials/deploy/` — a new structured tutorial for building, uploading, and instantiating a Soroban smart contract on Stellar testnet using StarForge.

**`tutorials/deploy/tutorial.json`**
- 5 steps: balance check → contract build → simulate (dry-run) → upload → on-chain verification
- Follows the same schema as `tutorials/hello-world/tutorial.json` (`slug`, `title`, `description`, `steps[]`)
- No code changes needed — `list_tutorial_slugs()` in `tutorial_engine.rs` auto-discovers any subdirectory under `tutorials/`, so `starforge tutorial list` and `starforge tutorial start deploy` work immediately

**`tutorials/deploy/README.md`**
- Documents the 5 milestones, prerequisites (hello-world completed, Stellar CLI installed), and the interactive `starforge tutorial start deploy` flow
- Links back to hello-world as a prerequisite