### PR TITLE
fix: correct three code bugs found during full codebase audit

### DIFF
--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -127,7 +127,7 @@ fn check_integer_overflows(content: &str, path: &Path) -> Result<Vec<LintFinding
             continue;
         }
 
-        let has_arithmetic = (line.contains(" + ") || line.contains(" + "))
+        let has_arithmetic = (line.contains(" + ") || line.contains("+="))
             && (line.contains("=") || line.contains("let") || line.contains("return"));
 
         if has_arithmetic {

--- a/src/commands/tx.rs
+++ b/src/commands/tx.rs
@@ -410,7 +410,7 @@ fn handle_send(args: SendArgs) -> Result<()> {
     );
     p::kv(
         "Transaction XDR",
-        &format!("{}...", &tx_result.transaction_xdr[..20]),
+        &format!("{}...", &tx_result.transaction_xdr[..tx_result.transaction_xdr.len().min(20)]),
     );
 
     // Build operation summary for confirmation

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -726,7 +726,7 @@ fn show(name: String, reveal: bool) -> Result<()> {
         if let Some(sk) = &w.secret_key {
             // Check if it's plaintext
             if !sk.contains(':') && sk.starts_with('S') && sk.len() == 56 {
-                p::warn("Warning: This wallet is using an unencrypted legacy key!");
+                p::warn("Warning: This wallet's secret key is stored unencrypted (plaintext)!");
                 p::kv("Secret Key", sk);
             } else {
                 let pwd = crypto::prompt_password(


### PR DESCRIPTION
Closes #399
Closes #403 
Closes #391
Closes #392
## Summary

Full codebase audit conducted while evaluating feasibility of adding social/collaboration features (team workflows, code review tooling, community engagement) to StarForge. Three confirmed bugs were found and fixed:

- **`src/commands/lint.rs`** — `check_integer_overflows` had a copy-paste duplicate: `line.contains(" + ") || line.contains(" + ")`. The second operand is now `"+="` so augmented-addition assignments (`x += y`) are actually detected instead of being silently missed.

- **`src/commands/tx.rs`** — `handle_send` previewed the transaction XDR with a bare `[..20]` slice that would panic if the XDR string were shorter than 20 characters. Fixed to use `.len().min(20)` (the same safe pattern already used in `handle_batch`).

- **`src/commands/wallet.rs`** — The warning shown when revealing a plaintext secret key said "unencrypted legacy key". The word *legacy* implies a deprecated format, but the key is simply unencrypted. Changed to "stored unencrypted (plaintext)" for clarity.

## Test plan

- [ ] `cargo check` passes (verified clean)
- [ ] Run `starforge lint <file>` on a file containing `+=` — confirm overflow warning fires
- [ ] Run `starforge tx send` in a test path where XDR preview is short — confirm no panic
- [ ] Run `starforge wallet show <name> --reveal` on a plaintext wallet — confirm updated warning text
