### PR TITLE
Expand gas analyzer estimates

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1024,7 +1024,7 @@ Gas analysis and optimization.
 
 #### `starforge gas analyze`
 
-Analyze gas costs.
+Analyze gas costs, resource usage, and optimization opportunities.
 
 **Usage:**
 ```bash
@@ -1034,6 +1034,13 @@ starforge gas analyze --wasm <FILE> [OPTIONS]
 **Options:**
 - `--wasm <FILE>` - Path to wasm file (required)
 - `--network <NETWORK>` - Network to use
+
+**Output includes:**
+- WASM size and SHA256 fingerprint
+- Heuristic score and gas risk level
+- Estimated CPU instructions, memory bytes, storage bytes, and fee in stroops
+- Host-call and control-flow operation counts
+- Optimization suggestions for large binaries, panic strings, debug printing, and expensive host-call patterns
 
 #### `starforge gas optimize`
 
@@ -1050,7 +1057,7 @@ starforge gas optimize --target <INPUT> --output <OUTPUT>
 
 #### `starforge gas diff`
 
-Compare two wasm builds side-by-side and diff estimated simulation cost.
+Compare two wasm builds side-by-side and detect estimated gas regressions.
 
 **Usage:**
 ```bash
@@ -1063,8 +1070,10 @@ starforge gas diff <OLD_WASM> <NEW_WASM>
 
 **Output includes:**
 - Old/new wasm size
-- Old/new estimated simulation cost
-- Delta and percentage change
+- Old/new estimated fee in stroops
+- Old/new estimated CPU instructions
+- Old/new gas risk level
+- Delta, percentage change, and regression classification
 - Profiling timings per analysis step
 
 ---

--- a/src/commands/gas.rs
+++ b/src/commands/gas.rs
@@ -59,6 +59,19 @@ fn analyze(wasm: PathBuf, network: Option<String>) -> Result<()> {
     p::kv_accent("Size (bytes)", &report.size_bytes.to_string());
     p::kv("SHA256", &report.sha256);
     p::kv("Heuristic score", &report.score.to_string());
+    p::kv("Risk", &format!("{:?}", report.risk));
+    p::kv(
+        "Estimated CPU",
+        &format!("{} instructions", report.gas.cpu_instructions),
+    );
+    p::kv("Estimated memory", &format!("{} bytes", report.gas.memory_bytes));
+    p::kv("Estimated storage", &format!("{} bytes", report.gas.storage_bytes));
+    p::kv("Estimated fee", &format!("{} stroops", report.gas.fee_stroops));
+    p::kv("Host calls", &report.resources.host_calls.to_string());
+    p::kv(
+        "Control flow ops",
+        &report.resources.control_flow_ops.to_string(),
+    );
     if !report.suggestions.is_empty() {
         println!();
         p::info("Suggestions:");
@@ -112,39 +125,49 @@ fn diff(old_wasm: PathBuf, new_wasm: PathBuf) -> Result<()> {
     profile.mark("analyze_old");
     let new_report = optimizer::analyze_wasm(&new_wasm)?;
     profile.mark("analyze_new");
-
-    let old_est = estimate_simulation_cost(old_report.size_bytes);
-    let new_est = estimate_simulation_cost(new_report.size_bytes);
-    let delta = new_est as i64 - old_est as i64;
-    let pct = if old_est == 0 {
-        0.0
-    } else {
-        (delta as f64 / old_est as f64) * 100.0
-    };
+    let comparison = optimizer::compare_gas_reports(&old_report, &new_report);
 
     println!();
     p::separator();
     p::kv("Old size (bytes)", &old_report.size_bytes.to_string());
     p::kv("New size (bytes)", &new_report.size_bytes.to_string());
-    p::kv("Old est. sim cost", &old_est.to_string());
-    p::kv("New est. sim cost", &new_est.to_string());
+    p::kv(
+        "Old est. fee",
+        &comparison.baseline_fee_stroops.to_string(),
+    );
+    p::kv(
+        "New est. fee",
+        &comparison.candidate_fee_stroops.to_string(),
+    );
+    p::kv(
+        "Old est. CPU",
+        &old_report.gas.cpu_instructions.to_string(),
+    );
+    p::kv(
+        "New est. CPU",
+        &new_report.gas.cpu_instructions.to_string(),
+    );
+    p::kv("Old risk", &format!("{:?}", old_report.risk));
+    p::kv("New risk", &format!("{:?}", new_report.risk));
     p::kv(
         "Estimated delta",
         &format!(
             "{} ({:+.2}%)",
-            if delta >= 0 {
-                format!("+{}", delta)
+            if comparison.delta_stroops >= 0 {
+                format!("+{}", comparison.delta_stroops)
             } else {
-                delta.to_string()
+                comparison.delta_stroops.to_string()
             },
-            pct
+            comparison.delta_percent
         ),
     );
     p::kv(
         "Result",
-        if delta < 0 {
+        if comparison.delta_stroops < 0 {
             "Improved (lower estimated cost)"
-        } else if delta > 0 {
+        } else if comparison.regression {
+            "Regressed (estimated fee increased by more than 5%)"
+        } else if comparison.delta_stroops > 0 {
             "Regressed (higher estimated cost)"
         } else {
             "No change"
@@ -160,8 +183,4 @@ fn diff(old_wasm: PathBuf, new_wasm: PathBuf) -> Result<()> {
     p::separator();
 
     Ok(())
-}
-
-fn estimate_simulation_cost(size_bytes: usize) -> u64 {
-    2_000 + (size_bytes as u64 / 8)
 }

--- a/src/utils/optimizer.rs
+++ b/src/utils/optimizer.rs
@@ -10,7 +10,43 @@ pub struct GasReport {
     pub size_bytes: usize,
     pub sha256: String,
     pub score: u32,
+    pub gas: GasCostEstimate,
+    pub resources: ResourceUsageEstimate,
+    pub risk: GasRisk,
     pub suggestions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GasCostEstimate {
+    pub cpu_instructions: u64,
+    pub memory_bytes: u64,
+    pub storage_bytes: u64,
+    pub fee_stroops: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceUsageEstimate {
+    pub wasm_bytes: usize,
+    pub host_calls: usize,
+    pub control_flow_ops: usize,
+    pub memory_pages: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum GasRisk {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GasComparison {
+    pub baseline_fee_stroops: u64,
+    pub candidate_fee_stroops: u64,
+    pub delta_stroops: i64,
+    pub delta_percent: f64,
+    pub regression: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,6 +93,21 @@ pub fn analyze_wasm(path: &Path) -> Result<GasReport> {
         suggestions.push("Debug printing detected; remove logs for production builds.".to_string());
     }
 
+    let resources = estimate_resource_usage(&bytes);
+    let gas = estimate_gas_cost(&resources);
+    let risk = classify_gas_risk(&gas, suggestions.len());
+
+    if gas.fee_stroops > 2_500 {
+        suggestions.push(
+            "Estimated invocation fee is high; profile storage access and host calls.".to_string(),
+        );
+    }
+    if resources.host_calls > 100 {
+        suggestions.push(
+            "Many host-call opcodes detected; batch reads and writes where possible.".to_string(),
+        );
+    }
+
     // A simple, stable scoring function.
     let score = (1_000_000usize.saturating_sub(size)).min(1_000_000) as u32;
 
@@ -64,8 +115,76 @@ pub fn analyze_wasm(path: &Path) -> Result<GasReport> {
         size_bytes: size,
         sha256,
         score,
+        gas,
+        resources,
+        risk,
         suggestions,
     })
+}
+
+pub fn compare_gas_reports(baseline: &GasReport, candidate: &GasReport) -> GasComparison {
+    let old_fee = baseline.gas.fee_stroops;
+    let new_fee = candidate.gas.fee_stroops;
+    let delta = new_fee as i64 - old_fee as i64;
+    let delta_percent = if old_fee == 0 {
+        0.0
+    } else {
+        (delta as f64 / old_fee as f64) * 100.0
+    };
+
+    GasComparison {
+        baseline_fee_stroops: old_fee,
+        candidate_fee_stroops: new_fee,
+        delta_stroops: delta,
+        delta_percent,
+        regression: delta_percent > 5.0,
+    }
+}
+
+fn estimate_resource_usage(bytes: &[u8]) -> ResourceUsageEstimate {
+    let host_calls = bytes
+        .iter()
+        .filter(|byte| matches!(byte, 0x10 | 0x11))
+        .count();
+    let control_flow_ops = bytes
+        .iter()
+        .filter(|byte| matches!(byte, 0x02 | 0x03 | 0x04 | 0x0c | 0x0d))
+        .count();
+    let memory_pages = ((bytes.len() as u64).saturating_add(65_535) / 65_536).max(1);
+
+    ResourceUsageEstimate {
+        wasm_bytes: bytes.len(),
+        host_calls,
+        control_flow_ops,
+        memory_pages,
+    }
+}
+
+fn estimate_gas_cost(resources: &ResourceUsageEstimate) -> GasCostEstimate {
+    let storage_markers = resources.host_calls as u64 / 4;
+    let cpu_instructions = resources.wasm_bytes as u64 * 25
+        + resources.host_calls as u64 * 1_000
+        + resources.control_flow_ops as u64 * 750;
+    let memory_bytes = resources.memory_pages * 65_536;
+    let storage_bytes = storage_markers * 256;
+    let fee_stroops = 100 + cpu_instructions / 10_000 + memory_bytes / 8_192 + storage_bytes / 32;
+
+    GasCostEstimate {
+        cpu_instructions,
+        memory_bytes,
+        storage_bytes,
+        fee_stroops,
+    }
+}
+
+fn classify_gas_risk(gas: &GasCostEstimate, suggestion_count: usize) -> GasRisk {
+    if gas.fee_stroops > 5_000 || suggestion_count >= 3 {
+        GasRisk::High
+    } else if gas.fee_stroops > 1_500 || suggestion_count > 0 {
+        GasRisk::Medium
+    } else {
+        GasRisk::Low
+    }
 }
 
 pub fn optimize_wasm(input: &Path, output: &Path) -> Result<OptimizeResult> {
@@ -154,4 +273,62 @@ fn run_external_optimizer(input: &Path, output: &Path) -> Result<String> {
         "No external Soroban optimizer completed successfully ({})",
         errors.join("; ")
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn analyze_wasm_includes_gas_and_resource_estimates() {
+        let tmp = tempdir().unwrap();
+        let wasm = tmp.path().join("contract.wasm");
+        fs::write(&wasm, [0x00, 0x61, 0x73, 0x6d, 0x10, 0x03, 0x04]).unwrap();
+
+        let report = analyze_wasm(&wasm).unwrap();
+
+        assert_eq!(report.size_bytes, 7);
+        assert_eq!(report.resources.host_calls, 1);
+        assert_eq!(report.resources.control_flow_ops, 2);
+        assert_eq!(report.resources.memory_pages, 1);
+        assert!(report.gas.cpu_instructions > 0);
+        assert!(report.gas.fee_stroops > 0);
+    }
+
+    #[test]
+    fn compare_gas_reports_flags_fee_regressions_above_threshold() {
+        let baseline = GasReport {
+            size_bytes: 1,
+            sha256: "old".to_string(),
+            score: 1,
+            gas: GasCostEstimate {
+                cpu_instructions: 10_000,
+                memory_bytes: 65_536,
+                storage_bytes: 0,
+                fee_stroops: 1_000,
+            },
+            resources: ResourceUsageEstimate {
+                wasm_bytes: 1,
+                host_calls: 0,
+                control_flow_ops: 0,
+                memory_pages: 1,
+            },
+            risk: GasRisk::Low,
+            suggestions: Vec::new(),
+        };
+        let candidate = GasReport {
+            gas: GasCostEstimate {
+                fee_stroops: 1_100,
+                ..baseline.gas.clone()
+            },
+            ..baseline.clone()
+        };
+
+        let comparison = compare_gas_reports(&baseline, &candidate);
+
+        assert_eq!(comparison.delta_stroops, 100);
+        assert!(comparison.regression);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds structured gas cost estimates to the existing WASM analyzer, including CPU instructions, memory bytes, storage bytes, and estimated fees in stroops.
- Adds deterministic resource usage estimates for WASM size, host-call opcodes, control-flow opcodes, and memory pages.
- Adds gas risk classification and additional optimization suggestions for expensive invocation patterns.
- Updates the gas diff command to compare estimated fees, CPU usage, risk level, and flag regressions above a 5% fee increase.
- Adds focused unit coverage for analyzer estimate output and regression detection.
- Documents the expanded gas analyzer output in the command reference.

Closes #328
Closes #334 
Closes #340 
Closes #366

## Notes

The implementation builds on the existing lightweight heuristic analyzer instead of introducing external profiling dependencies. This keeps the command deterministic and usable in local/offline workflows while giving developers clearer cost and regression signals.