### PR TITLE
Closes #349 (D-12: Implement Gas Optimization Analyzer)

### DIFF
--- a/docs/GAS_OPTIMIZATION_BEST_PRACTICES.md
+++ b/docs/GAS_OPTIMIZATION_BEST_PRACTICES.md
@@ -1,0 +1,82 @@
+# Gas Optimization Best Practices
+
+A practical guide to writing cheaper, faster Soroban contracts, and to using
+`starforge gas` to verify your changes actually help.
+
+## Using the analyzer
+
+```bash
+# Profile a single contract
+starforge gas analyze ./target/wasm32-unknown-unknown/release/my_contract.wasm
+
+# Export a shareable HTML report
+starforge gas analyze ./my_contract.wasm --format html --output report.html
+
+# Export a machine-readable report for CI
+starforge gas analyze ./my_contract.wasm --format json --output report.json
+
+# Compare two builds (e.g. before/after a refactor)
+starforge gas diff ./old.wasm ./new.wasm
+
+# Benchmark every contract in a directory
+starforge gas benchmark --dir ./target/wasm32-unknown-unknown/release
+```
+
+## What drives cost
+
+The analyzer estimates cost from four signals pulled out of the compiled
+wasm: binary size, host-call opcodes, control-flow opcodes, and memory
+pages. In practice, these map to concrete habits:
+
+**Binary size.** Every byte you ship is parsed and loaded. Strip debug
+symbols and avoid pulling in large dependencies you only use a sliver of.
+`cargo build --release` plus `starforge gas optimize` (which shells out to
+`soroban-optimize` / `stellar contract optimize` when available) should be
+your default release pipeline, not an afterthought.
+
+**Host calls.** Every interaction with the Soroban host — storage
+reads/writes, cross-contract calls, crypto operations — costs far more than
+plain computation inside the wasm sandbox. Batch reads instead of calling
+`get` in a loop; batch writes instead of writing the same key repeatedly
+inside one invocation. If you find yourself calling a host function inside a
+loop, that is almost always the first place to optimize.
+
+**Storage shape.** Prefer fewer, larger storage entries over many small
+ones where your access pattern allows it — each entry has fixed overhead.
+Conversely, don't over-pack unrelated data into one key if it forces you to
+read everything just to touch one field; that trades write cost for read
+cost. Profile both directions if you're unsure.
+
+**Control flow.** Deep branching and large match/loop structures inflate
+both code size and CPU instruction estimates. This is rarely worth
+micro-optimizing on its own, but it's a useful signal that a function has
+grown too complex and might benefit from being split or simplified anyway.
+
+**Logging and panics.** Debug `println!`/`panic!` strings get compiled into
+the binary and inflate size for no runtime benefit in production builds.
+Strip them, or gate them behind a debug feature flag.
+
+## A practical workflow
+
+1. Write the contract normally, correctness first.
+2. Run `starforge gas analyze` and read the suggestions — they're
+   heuristic, not gospel, but they flag the cheap wins.
+3. Make the change, then run `starforge gas diff old.wasm new.wasm` to
+   confirm the estimated fee actually went down. Don't optimize blind —
+   verify.
+4. Before merging, run `starforge gas benchmark --dir <build-output>` over
+   your whole contract suite so a regression in one function doesn't slip
+   through unnoticed while you were focused on another.
+5. Treat a `regression` flag (>5% fee increase) on `gas diff` the same way
+   you'd treat a failing test in CI — investigate before merging, don't
+   wave it through.
+
+## Caveats
+
+These are **heuristic, static estimates** derived from the compiled wasm,
+not a live Soroban RPC simulation. They're useful for fast local iteration
+and catching regressions early, but before deploying to mainnet, always
+cross-check the actual resource/fee numbers from `stellar contract
+simulate` or `soroban contract invoke --send=no` against what the analyzer
+predicted. Treat `starforge gas` as a fast first-pass filter, not the final
+word on what you'll pay on-chain.

--- a/src/commands/gas.rs
+++ b/src/commands/gas.rs
@@ -1,4 +1,8 @@
-use crate::utils::{config, optimizer, print as p, profiler};
+use crate::utils::{
+    config,
+    gas_report::{self, ReportFormat},
+    optimizer, print as p, profiler,
+};
 use anyhow::Result;
 use clap::Subcommand;
 use std::path::PathBuf;
@@ -12,6 +16,12 @@ pub enum GasCommands {
         /// Network context (used for fee heuristics)
         #[arg(long)]
         network: Option<String>,
+        /// Report format: text, json, or html
+        #[arg(long, default_value = "text")]
+        format: String,
+        /// Write the report to this file (required for json/html)
+        #[arg(long)]
+        output: Option<PathBuf>,
     },
     /// Emit an "optimized" wasm (lightweight, heuristic-based)
     Optimize {
@@ -28,32 +38,77 @@ pub enum GasCommands {
         old_wasm: PathBuf,
         /// Path to the candidate wasm
         new_wasm: PathBuf,
+        /// Report format: text, json, or html
+        #[arg(long, default_value = "text")]
+        format: String,
+        /// Write the report to this file (required for json/html)
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+    /// Run the gas analyzer over every .wasm file in a directory (benchmarking suite)
+    Benchmark {
+        /// Directory containing .wasm files to benchmark
+        #[arg(long, default_value = ".")]
+        dir: PathBuf,
+        /// Output as JSON instead of a table
+        #[arg(long)]
+        json: bool,
     },
 }
 
 pub async fn handle(cmd: GasCommands) -> Result<()> {
     match cmd {
-        GasCommands::Analyze { wasm, network } => analyze(wasm, network),
+        GasCommands::Analyze {
+            wasm,
+            network,
+            format,
+            output,
+        } => analyze(wasm, network, format, output),
         GasCommands::Optimize { target, output } => optimize(target, output),
-        GasCommands::Diff { old_wasm, new_wasm } => diff(old_wasm, new_wasm),
+        GasCommands::Diff {
+            old_wasm,
+            new_wasm,
+            format,
+            output,
+        } => diff(old_wasm, new_wasm, format, output),
+        GasCommands::Benchmark { dir, json } => benchmark(dir, json),
     }
 }
 
-fn analyze(wasm: PathBuf, network: Option<String>) -> Result<()> {
+fn analyze(
+    wasm: PathBuf,
+    network: Option<String>,
+    format: String,
+    output: Option<PathBuf>,
+) -> Result<()> {
     config::validate_file_path(&wasm, Some("wasm"))?;
 
     let cfg = config::load()?;
     let network = network.unwrap_or(cfg.network);
     config::validate_network(&network)?;
 
-    p::header("Gas Analyzer");
-    p::kv("Network", &network);
-    p::kv("Wasm", &wasm.display().to_string());
+    let report_format = ReportFormat::parse(&format)?;
+    let label = wasm
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| wasm.display().to_string());
 
     let t = profiler::Timer::start();
     let report = optimizer::analyze_wasm(&wasm)?;
     let elapsed = t.elapsed();
 
+    if matches!(report_format, ReportFormat::Json | ReportFormat::Html) {
+        let out = output.ok_or_else(|| {
+            anyhow::anyhow!("--output <path> is required when --format is json or html")
+        })?;
+        gas_report::write_report(&report, &label, report_format, &out)?;
+        p::success(&format!("Report written to {}", out.display()));
+        return Ok(());
+    }
+
+    p::header("Gas Analyzer");
+    p::kv("Network", &network);
+    p::kv("Wasm", &wasm.display().to_string());
     println!();
     p::separator();
     p::kv_accent("Size (bytes)", &report.size_bytes.to_string());
@@ -112,13 +167,24 @@ fn optimize(target: PathBuf, output: PathBuf) -> Result<()> {
     Ok(())
 }
 
-fn diff(old_wasm: PathBuf, new_wasm: PathBuf) -> Result<()> {
+fn diff(
+    old_wasm: PathBuf,
+    new_wasm: PathBuf,
+    format: String,
+    output: Option<PathBuf>,
+) -> Result<()> {
     config::validate_file_path(&old_wasm, Some("wasm"))?;
     config::validate_file_path(&new_wasm, Some("wasm"))?;
 
-    p::header("Gas Diff");
-    p::kv("Old wasm", &old_wasm.display().to_string());
-    p::kv("New wasm", &new_wasm.display().to_string());
+    let report_format = ReportFormat::parse(&format)?;
+    let old_label = old_wasm
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| old_wasm.display().to_string());
+    let new_label = new_wasm
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| new_wasm.display().to_string());
 
     let mut profile = profiler::Profiler::start();
     let old_report = optimizer::analyze_wasm(&old_wasm)?;
@@ -127,26 +193,34 @@ fn diff(old_wasm: PathBuf, new_wasm: PathBuf) -> Result<()> {
     profile.mark("analyze_new");
     let comparison = optimizer::compare_gas_reports(&old_report, &new_report);
 
+    if matches!(report_format, ReportFormat::Json | ReportFormat::Html) {
+        let out = output.ok_or_else(|| {
+            anyhow::anyhow!("--output <path> is required when --format is json or html")
+        })?;
+        gas_report::write_diff_report(
+            &old_label,
+            &old_report,
+            &new_label,
+            &new_report,
+            &comparison,
+            report_format,
+            &out,
+        )?;
+        p::success(&format!("Diff report written to {}", out.display()));
+        return Ok(());
+    }
+
+    p::header("Gas Diff");
+    p::kv("Old wasm", &old_wasm.display().to_string());
+    p::kv("New wasm", &new_wasm.display().to_string());
     println!();
     p::separator();
     p::kv("Old size (bytes)", &old_report.size_bytes.to_string());
     p::kv("New size (bytes)", &new_report.size_bytes.to_string());
-    p::kv(
-        "Old est. fee",
-        &comparison.baseline_fee_stroops.to_string(),
-    );
-    p::kv(
-        "New est. fee",
-        &comparison.candidate_fee_stroops.to_string(),
-    );
-    p::kv(
-        "Old est. CPU",
-        &old_report.gas.cpu_instructions.to_string(),
-    );
-    p::kv(
-        "New est. CPU",
-        &new_report.gas.cpu_instructions.to_string(),
-    );
+    p::kv("Old est. fee", &comparison.baseline_fee_stroops.to_string());
+    p::kv("New est. fee", &comparison.candidate_fee_stroops.to_string());
+    p::kv("Old est. CPU", &old_report.gas.cpu_instructions.to_string());
+    p::kv("New est. CPU", &new_report.gas.cpu_instructions.to_string());
     p::kv("Old risk", &format!("{:?}", old_report.risk));
     p::kv("New risk", &format!("{:?}", new_report.risk));
     p::kv(
@@ -181,6 +255,88 @@ fn diff(old_wasm: PathBuf, new_wasm: PathBuf) -> Result<()> {
     }
     p::kv("Total profile", &format!("{:?}", profile.total_elapsed()));
     p::separator();
+
+    Ok(())
+}
+
+fn benchmark(dir: PathBuf, json: bool) -> Result<()> {
+    if !dir.is_dir() {
+        anyhow::bail!("{} is not a directory", dir.display());
+    }
+
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {e}", dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("wasm"))
+        .collect();
+    entries.sort();
+
+    if entries.is_empty() {
+        anyhow::bail!("No .wasm files found in {}", dir.display());
+    }
+
+    let mut results = Vec::new();
+    for path in &entries {
+        match optimizer::analyze_wasm(path) {
+            Ok(report) => {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                results.push((name, report));
+            }
+            Err(e) => {
+                p::warn(&format!("Skipping {}: {e}", path.display()));
+            }
+        }
+    }
+
+    if json {
+        let payload: Vec<_> = results
+            .iter()
+            .map(|(name, r)| serde_json::json!({ "file": name, "report": r }))
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    p::header("Gas Benchmark Suite");
+    p::kv("Directory", &dir.display().to_string());
+    p::kv("Contracts analyzed", &results.len().to_string());
+    println!();
+
+    let headers = ["File", "Size (B)", "Fee (stroops)", "CPU instr.", "Risk"];
+    let rows: Vec<Vec<String>> = results
+        .iter()
+        .map(|(name, r)| {
+            vec![
+                name.clone(),
+                r.size_bytes.to_string(),
+                r.gas.fee_stroops.to_string(),
+                r.gas.cpu_instructions.to_string(),
+                format!("{:?}", r.risk),
+            ]
+        })
+        .collect();
+    p::table(&headers, &rows);
+
+    if let Some((cheapest_name, cheapest)) =
+        results.iter().min_by_key(|(_, r)| r.gas.fee_stroops)
+    {
+        p::success(&format!(
+            "Cheapest: {cheapest_name} ({} stroops)",
+            cheapest.gas.fee_stroops
+        ));
+    }
+    if let Some((priciest_name, priciest)) =
+        results.iter().max_by_key(|(_, r)| r.gas.fee_stroops)
+    {
+        p::warn(&format!(
+            "Most expensive: {priciest_name} ({} stroops)",
+            priciest.gas.fee_stroops
+        ));
+    }
 
     Ok(())
 }

--- a/src/utils/gas_report.rs
+++ b/src/utils/gas_report.rs
@@ -1,0 +1,266 @@
+use crate::utils::optimizer::{GasComparison, GasReport};
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+/// Supported output formats for gas reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportFormat {
+    Text,
+    Json,
+    Html,
+}
+
+impl ReportFormat {
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "text" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            "html" => Ok(Self::Html),
+            other => anyhow::bail!("Unknown report format '{other}'. Use text, json, or html."),
+        }
+    }
+}
+
+/// Write a single-contract gas report to disk in the requested format.
+pub fn write_report(
+    report: &GasReport,
+    label: &str,
+    format: ReportFormat,
+    output: &Path,
+) -> Result<()> {
+    let body = match format {
+        ReportFormat::Json => serde_json::to_string_pretty(report)
+            .context("Failed to serialize gas report as JSON")?,
+        ReportFormat::Html => render_html(label, report),
+        ReportFormat::Text => {
+            anyhow::bail!("Text format is printed to stdout, not written to a file")
+        }
+    };
+    write_to_path(output, &body)
+}
+
+/// Write a two-contract comparison report (old vs new) to disk.
+#[allow(clippy::too_many_arguments)]
+pub fn write_diff_report(
+    old_label: &str,
+    old: &GasReport,
+    new_label: &str,
+    new: &GasReport,
+    comparison: &GasComparison,
+    format: ReportFormat,
+    output: &Path,
+) -> Result<()> {
+    let body = match format {
+        ReportFormat::Json => {
+            let combined = serde_json::json!({
+                "old": { "label": old_label, "report": old },
+                "new": { "label": new_label, "report": new },
+                "comparison": comparison,
+            });
+            serde_json::to_string_pretty(&combined)
+                .context("Failed to serialize gas diff as JSON")?
+        }
+        ReportFormat::Html => render_html_diff(old_label, old, new_label, new, comparison),
+        ReportFormat::Text => {
+            anyhow::bail!("Text format is printed to stdout, not written to a file")
+        }
+    };
+    write_to_path(output, &body)
+}
+
+fn write_to_path(output: &Path, body: &str) -> Result<()> {
+    if let Some(parent) = output.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+    }
+    fs::write(output, body).with_context(|| format!("Failed to write {}", output.display()))
+}
+
+fn bar(value: u64, max: u64, color: &str) -> String {
+    let pct = if max == 0 {
+        0.0
+    } else {
+        (value as f64 / max as f64) * 100.0
+    };
+    format!(
+        r#"<div class="bar-track"><div class="bar-fill" style="width:{pct:.1}%;background:{color}"></div></div>"#
+    )
+}
+
+const STYLE: &str = r#"
+body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; background:#0f1115; color:#e6e6e6; padding:32px; }
+h1 { font-size: 20px; margin-bottom: 4px; }
+.sub { color:#9aa0a6; margin-bottom: 24px; font-size: 13px; }
+table { width:100%; border-collapse: collapse; margin-bottom: 24px; }
+td, th { text-align:left; padding: 8px 10px; border-bottom: 1px solid #262a33; font-size: 13px; }
+.bar-track { background:#1c2027; border-radius:4px; height:10px; width:200px; overflow:hidden; }
+.bar-fill { height:100%; border-radius:4px; }
+.suggestions { background:#1c2027; padding:16px; border-radius:8px; }
+.suggestions li { margin-bottom:6px; }
+.risk-low { color:#4caf50; } .risk-medium { color:#ffb300; } .risk-high { color:#f44336; }
+"#;
+
+fn render_html(label: &str, r: &GasReport) -> String {
+    let max = r
+        .gas
+        .cpu_instructions
+        .max(r.gas.memory_bytes)
+        .max(r.gas.storage_bytes)
+        .max(r.gas.fee_stroops)
+        .max(1);
+    let risk_class = match r.risk {
+        crate::utils::optimizer::GasRisk::Low => "risk-low",
+        crate::utils::optimizer::GasRisk::Medium => "risk-medium",
+        crate::utils::optimizer::GasRisk::High => "risk-high",
+    };
+    let suggestions = if r.suggestions.is_empty() {
+        "<p>No suggestions — looks efficient.</p>".to_string()
+    } else {
+        let items: String = r
+            .suggestions
+            .iter()
+            .map(|s| format!("<li>{s}</li>"))
+            .collect();
+        format!("<ul>{items}</ul>")
+    };
+
+    format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><title>Gas Report — {label}</title><style>{STYLE}</style></head>
+<body>
+<h1>Gas Report: {label}</h1>
+<p class="sub">Size: {size} bytes &middot; SHA256: {sha} &middot; Risk: <span class="{risk_class}">{risk:?}</span></p>
+<table>
+<tr><th>Metric</th><th>Value</th><th></th></tr>
+<tr><td>CPU instructions</td><td>{cpu}</td><td>{cpu_bar}</td></tr>
+<tr><td>Memory (bytes)</td><td>{mem}</td><td>{mem_bar}</td></tr>
+<tr><td>Storage (bytes)</td><td>{storage}</td><td>{storage_bar}</td></tr>
+<tr><td>Fee (stroops)</td><td>{fee}</td><td>{fee_bar}</td></tr>
+<tr><td>Host calls</td><td>{host_calls}</td><td></td></tr>
+<tr><td>Control flow ops</td><td>{cf_ops}</td><td></td></tr>
+</table>
+<h2>Suggestions</h2>
+<div class="suggestions">{suggestions}</div>
+</body></html>"#,
+        label = label,
+        size = r.size_bytes,
+        sha = r.sha256,
+        risk_class = risk_class,
+        risk = r.risk,
+        cpu = r.gas.cpu_instructions,
+        cpu_bar = bar(r.gas.cpu_instructions, max, "#5b8def"),
+        mem = r.gas.memory_bytes,
+        mem_bar = bar(r.gas.memory_bytes, max, "#9d6bff"),
+        storage = r.gas.storage_bytes,
+        storage_bar = bar(r.gas.storage_bytes, max, "#28c2a0"),
+        fee = r.gas.fee_stroops,
+        fee_bar = bar(r.gas.fee_stroops, max, "#ff9d4d"),
+        host_calls = r.resources.host_calls,
+        cf_ops = r.resources.control_flow_ops,
+    )
+}
+
+fn render_html_diff(
+    old_label: &str,
+    old: &GasReport,
+    new_label: &str,
+    new: &GasReport,
+    cmp: &GasComparison,
+) -> String {
+    let max = old.gas.fee_stroops.max(new.gas.fee_stroops).max(1);
+    let verdict = if cmp.delta_stroops < 0 {
+        "Improved"
+    } else if cmp.regression {
+        "Regressed (>5%)"
+    } else if cmp.delta_stroops > 0 {
+        "Regressed"
+    } else {
+        "No change"
+    };
+
+    format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><title>Gas Diff</title><style>{STYLE}</style></head>
+<body>
+<h1>Gas Comparison</h1>
+<p class="sub">{old_label} &rarr; {new_label}</p>
+<table>
+<tr><th></th><th>{old_label}</th><th>{new_label}</th></tr>
+<tr><td>Fee (stroops)</td><td>{old_fee}</td><td>{new_fee}</td></tr>
+<tr><td></td><td>{old_bar}</td><td>{new_bar}</td></tr>
+<tr><td>CPU instructions</td><td>{old_cpu}</td><td>{new_cpu}</td></tr>
+<tr><td>Size (bytes)</td><td>{old_size}</td><td>{new_size}</td></tr>
+</table>
+<h2>Result: {verdict} ({delta:+} stroops, {delta_pct:+.2}%)</h2>
+</body></html>"#,
+        old_label = old_label,
+        new_label = new_label,
+        old_fee = old.gas.fee_stroops,
+        new_fee = new.gas.fee_stroops,
+        old_bar = bar(old.gas.fee_stroops, max, "#5b8def"),
+        new_bar = bar(new.gas.fee_stroops, max, "#ff9d4d"),
+        old_cpu = old.gas.cpu_instructions,
+        new_cpu = new.gas.cpu_instructions,
+        old_size = old.size_bytes,
+        new_size = new.size_bytes,
+        verdict = verdict,
+        delta = cmp.delta_stroops,
+        delta_pct = cmp.delta_percent,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::optimizer::{GasCostEstimate, GasRisk, ResourceUsageEstimate};
+    use tempfile::tempdir;
+
+    fn sample_report() -> GasReport {
+        GasReport {
+            size_bytes: 100,
+            sha256: "abc".to_string(),
+            score: 50,
+            gas: GasCostEstimate {
+                cpu_instructions: 1000,
+                memory_bytes: 65536,
+                storage_bytes: 256,
+                fee_stroops: 200,
+            },
+            resources: ResourceUsageEstimate {
+                wasm_bytes: 100,
+                host_calls: 2,
+                control_flow_ops: 3,
+                memory_pages: 1,
+            },
+            risk: GasRisk::Low,
+            suggestions: vec!["test suggestion".to_string()],
+        }
+    }
+
+    #[test]
+    fn writes_json_report() {
+        let tmp = tempdir().unwrap();
+        let out = tmp.path().join("report.json");
+        write_report(&sample_report(), "test", ReportFormat::Json, &out).unwrap();
+        let content = fs::read_to_string(&out).unwrap();
+        assert!(content.contains("\"fee_stroops\": 200"));
+    }
+
+    #[test]
+    fn writes_html_report() {
+        let tmp = tempdir().unwrap();
+        let out = tmp.path().join("report.html");
+        write_report(&sample_report(), "test", ReportFormat::Html, &out).unwrap();
+        let content = fs::read_to_string(&out).unwrap();
+        assert!(content.contains("<html>"));
+        assert!(content.contains("test suggestion"));
+    }
+
+    #[test]
+    fn parses_format_strings() {
+        assert!(matches!(ReportFormat::parse("json").unwrap(), ReportFormat::Json));
+        assert!(matches!(ReportFormat::parse("HTML").unwrap(), ReportFormat::Html));
+        assert!(ReportFormat::parse("bogus").is_err());
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod gas_report;
 pub mod backup;
 pub mod benchmarking;
 pub mod bindings;


### PR DESCRIPTION
## Summary

Closes #349 (D-12: Implement Gas Optimization Analyzer)

Gas profiling, optimization suggestions, and version diffing already
landed via #434. This PR completes the remaining acceptance criteria
from #349 that weren't covered there:

- **Gas reports and visualizations** — `starforge gas analyze` and
  `starforge gas diff` now support `--format json` and `--format html`
  (in addition to the existing text output), writing to a file via
  `--output <path>`. The HTML report renders a self-contained,
  dependency-free visual report with relative bar charts for CPU,
  memory, storage, and fee estimates.
- **Gas benchmarking suite** — new `starforge gas benchmark --dir <path>`
  subcommand runs the analyzer over every `.wasm` file in a directory and
  prints a summary table (or `--json` for machine-readable output),
  highlighting the cheapest and most expensive contracts in the set.
- **Optimization best practices guide** — added
  `docs/GAS_OPTIMIZATION_BEST_PRACTICES.md` covering what drives cost
  (binary size, host calls, storage shape, control flow, debug
  logging/panics), a practical optimize-and-verify workflow, and an
  explicit caveat that these are static heuristic estimates, not a
  substitute for `stellar contract simulate` before mainnet deploys.

## Changes

- `src/commands/gas.rs` — added `--format`/`--output` flags to
  `analyze`/`diff`, added new `benchmark` subcommand
- `src/utils/gas_report.rs` (new) — JSON/HTML report rendering for
  single reports and diffs
- `src/utils/mod.rs` — registered the new `gas_report` module
- `docs/GAS_OPTIMIZATION_BEST_PRACTICES.md` (new) — best practices guide

## Testing

- Unit tests added in `gas_report.rs` covering JSON output, HTML output,
  and format-string parsing
- Manually verified `gas analyze --format html --output report.html` and
  `gas benchmark --dir <folder>` against sample `.wasm` files

## Notes for reviewers

This intentionally does not touch `src/utils/optimizer.rs` or the
existing `analyze`/`optimize`/`diff` logic merged in #434 — only adds
new export formats and a new subcommand on top of it, to minimize merge
risk.