### PR TITLE
feat: add multisig transaction builder ui

### DIFF
--- a/docs/COMMAND_REFERENCE.md
+++ b/docs/COMMAND_REFERENCE.md
@@ -52,6 +52,29 @@ starforge tutorial next
 
 ---
 
+## `multisig`
+
+| Subcommand | Purpose |
+|------------|---------|
+| `wizard` | Interactive transaction proposal builder |
+| `create` | Create a proposal with threshold, signers, metadata, and optional transaction XDR |
+| `status <FILE>` | Show visual signature collection progress |
+| `verify <FILE>` | Validate signatures, duplicates, pending signers, and threshold readiness |
+| `notify <FILE>` | Queue signature request notifications for pending signers |
+| `export <FILE>` / `import <FILE>` | Share proposal JSON between signers |
+| `templates` / `from-template` | Use common scenarios like escrow, company treasury, DAO, vault, and payment |
+
+```bash
+starforge multisig wizard
+starforge multisig create --threshold 2 --signers alice,bob,carol \
+  --title "Treasury payment" --transaction-xdr <XDR>
+starforge multisig status proposal.json
+starforge multisig verify proposal.json
+starforge multisig notify proposal.json --message "Please sign the treasury payment"
+```
+
+---
+
 ## `new`
 
 | Subcommand | Purpose |

--- a/src/commands/multisig_builder.rs
+++ b/src/commands/multisig_builder.rs
@@ -1,7 +1,10 @@
-use crate::utils::{multisig_builder as multisig, print as p};
+use crate::utils::{multisig_builder as multisig, notifications, print as p};
 use anyhow::Result;
 use clap::Subcommand;
-use std::path::PathBuf;
+use colored::Colorize;
+use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 #[derive(Subcommand)]
 pub enum MultisigCommands {
@@ -10,25 +13,36 @@ pub enum MultisigCommands {
         /// Minimum signatures required
         #[arg(long)]
         threshold: u32,
-        /// Signers (comma-separated public keys)
+        /// Signers (comma-separated names or public keys)
         #[arg(long)]
         signers: String,
         /// Transaction network
         #[arg(long, default_value = "testnet")]
         network: String,
+        /// Human-readable proposal title
+        #[arg(long)]
+        title: Option<String>,
+        /// Proposal description
+        #[arg(long)]
+        description: Option<String>,
+        /// Transaction envelope/XDR to collect signatures for
+        #[arg(long)]
+        transaction_xdr: Option<String>,
     },
+    /// Interactive multi-sig transaction builder
+    Wizard,
     /// Add a signer to proposal
     AddSigner {
         /// Proposal file path
         proposal: PathBuf,
-        /// Signer public key
+        /// Signer name or public key
         signer: String,
     },
-    /// Sign proposal with wallet
+    /// Sign proposal with wallet/signer name
     Sign {
         /// Proposal file path
         proposal: PathBuf,
-        /// Signer wallet name
+        /// Signer wallet/name
         wallet: String,
     },
     /// View proposal details and signatures
@@ -40,6 +54,19 @@ pub enum MultisigCommands {
     Status {
         /// Proposal file path
         proposal: PathBuf,
+    },
+    /// Verify signatures and approval threshold
+    Verify {
+        /// Proposal file path
+        proposal: PathBuf,
+    },
+    /// Send signature request notifications for pending signers
+    Notify {
+        /// Proposal file path
+        proposal: PathBuf,
+        /// Optional custom notification message
+        #[arg(long)]
+        message: Option<String>,
     },
     /// Submit signed proposal to network
     Submit {
@@ -71,6 +98,9 @@ pub enum MultisigCommands {
         template: String,
         /// Output file path
         output: PathBuf,
+        /// Transaction network
+        #[arg(long, default_value = "testnet")]
+        network: String,
     },
 }
 
@@ -80,203 +110,328 @@ pub async fn handle(cmd: MultisigCommands) -> Result<()> {
             threshold,
             signers,
             network,
-        } => create_proposal(threshold, &signers, &network),
+            title,
+            description,
+            transaction_xdr,
+        } => create_proposal(
+            threshold,
+            &signers,
+            &network,
+            title,
+            description,
+            transaction_xdr,
+        ),
+        MultisigCommands::Wizard => interactive_wizard(),
         MultisigCommands::AddSigner { proposal, signer } => add_signer(&proposal, &signer),
         MultisigCommands::Sign { proposal, wallet } => sign_proposal(&proposal, &wallet),
         MultisigCommands::View { proposal } => view_proposal(&proposal),
         MultisigCommands::Status { proposal } => check_status(&proposal),
+        MultisigCommands::Verify { proposal } => verify_proposal(&proposal),
+        MultisigCommands::Notify { proposal, message } => notify_signers(&proposal, message),
         MultisigCommands::Submit { proposal, network } => submit_proposal(&proposal, &network),
         MultisigCommands::Export { proposal, output } => export_proposal(&proposal, output),
         MultisigCommands::Import { input, output } => import_proposal(&input, output),
         MultisigCommands::Templates => list_templates(),
-        MultisigCommands::FromTemplate { template, output } => from_template(&template, &output),
+        MultisigCommands::FromTemplate {
+            template,
+            output,
+            network,
+        } => from_template(&template, &output, &network),
     }
 }
 
-fn create_proposal(threshold: u32, signers: &str, network: &str) -> Result<()> {
-    p::info(&format!(
-        "Creating {}-of-{} multi-sig proposal",
-        threshold,
-        signers.split(',').count()
-    ));
+fn create_proposal(
+    threshold: u32,
+    signers: &str,
+    network: &str,
+    title: Option<String>,
+    description: Option<String>,
+    transaction_xdr: Option<String>,
+) -> Result<()> {
+    let signer_list = parse_signers(signers);
+    validate_threshold(threshold, signer_list.len())?;
 
-    let signer_list: Vec<String> = signers.split(',').map(|s| s.trim().to_string()).collect();
-
-    if threshold as usize > signer_list.len() {
-        anyhow::bail!("Threshold cannot exceed number of signers");
-    }
-
-    let proposal = multisig::Proposal::new(threshold, signer_list, network.to_string());
+    let mut proposal = multisig::Proposal::new(threshold, signer_list, network.to_string());
+    proposal.metadata.title = title;
+    proposal.metadata.description = description;
+    proposal.transaction_xdr = transaction_xdr;
     let filename = format!("proposal_{}.json", uuid::Uuid::new_v4());
 
-    std::fs::write(&filename, serde_json::to_string_pretty(&proposal)?)?;
+    save_proposal(Path::new(&filename), &proposal)?;
 
     println!();
-    println!("  Proposal: {}", colored::Colorize::cyan(filename.as_str()));
-    println!("  Threshold: {}/{}", threshold, signers.split(',').count());
-    println!("  Network: {}", network);
-    println!();
-
     p::success(&format!("Proposal created: {}", filename));
+    p::kv(
+        "Threshold",
+        &format!("{}/{}", threshold, proposal.signers.len()),
+    );
+    p::kv("Network", network);
+    print_progress(&proposal);
+    Ok(())
+}
+
+fn interactive_wizard() -> Result<()> {
+    let theme = ColorfulTheme::default();
+    p::header("Interactive Multi-Sig Builder");
+
+    let templates = multisig::common_templates();
+    let mut choices = vec!["blank custom proposal".to_string()];
+    choices.extend(
+        templates
+            .iter()
+            .map(|template| format!("{} - {}", template.name, template.description)),
+    );
+
+    let selected = Select::with_theme(&theme)
+        .with_prompt("Choose a starting point")
+        .items(&choices)
+        .default(0)
+        .interact()?;
+
+    let network: String = Input::with_theme(&theme)
+        .with_prompt("Network")
+        .default("testnet".to_string())
+        .interact_text()?;
+
+    let mut proposal = if selected == 0 {
+        let threshold: u32 = Input::with_theme(&theme)
+            .with_prompt("Required signatures")
+            .default(2)
+            .interact_text()?;
+        let signers: String = Input::with_theme(&theme)
+            .with_prompt("Signers (comma-separated names or public keys)")
+            .interact_text()?;
+        let signer_list = parse_signers(&signers);
+        validate_threshold(threshold, signer_list.len())?;
+        multisig::Proposal::new(threshold, signer_list, network)
+    } else {
+        multisig::proposal_from_template(templates[selected - 1].name, network)?
+    };
+
+    let title: String = Input::with_theme(&theme)
+        .with_prompt("Title")
+        .default(
+            proposal
+                .metadata
+                .title
+                .clone()
+                .unwrap_or_else(|| "Multi-sig transaction".to_string()),
+        )
+        .interact_text()?;
+    proposal.metadata.title = Some(title);
+
+    let description: String = Input::with_theme(&theme)
+        .with_prompt("Description")
+        .allow_empty(true)
+        .interact_text()?;
+    if !description.trim().is_empty() {
+        proposal.metadata.description = Some(description);
+    }
+
+    let transaction_xdr: String = Input::with_theme(&theme)
+        .with_prompt("Transaction XDR/envelope (optional)")
+        .allow_empty(true)
+        .interact_text()?;
+    if !transaction_xdr.trim().is_empty() {
+        proposal.transaction_xdr = Some(transaction_xdr);
+    }
+
+    let output: String = Input::with_theme(&theme)
+        .with_prompt("Output proposal JSON")
+        .default(format!("proposal_{}.json", proposal.id))
+        .interact_text()?;
+    save_proposal(Path::new(&output), &proposal)?;
+
+    println!();
+    p::success(&format!("Proposal created: {}", output));
+    print_progress(&proposal);
+
+    if Confirm::with_theme(&theme)
+        .with_prompt("Queue signature request notifications now?")
+        .default(false)
+        .interact()?
+    {
+        notify_for_proposal(&proposal, None)?;
+    }
 
     Ok(())
 }
 
-fn add_signer(proposal_path: &std::path::Path, signer: &str) -> Result<()> {
-    let contents = std::fs::read_to_string(proposal_path)?;
-    let mut proposal: multisig::Proposal = serde_json::from_str(&contents)?;
+fn add_signer(proposal_path: &Path, signer: &str) -> Result<()> {
+    let mut proposal = load_proposal(proposal_path)?;
+    let signer = signer.trim();
 
     if proposal.signers.contains(&signer.to_string()) {
         anyhow::bail!("Signer already in proposal");
     }
 
     proposal.signers.push(signer.to_string());
-    std::fs::write(proposal_path, serde_json::to_string_pretty(&proposal)?)?;
+    save_proposal(proposal_path, &proposal)?;
 
     p::success(&format!("Signer added: {}", signer));
-
+    print_progress(&proposal);
     Ok(())
 }
 
-fn sign_proposal(proposal_path: &std::path::Path, wallet: &str) -> Result<()> {
-    let contents = std::fs::read_to_string(proposal_path)?;
-    let mut proposal: multisig::Proposal = serde_json::from_str(&contents)?;
+fn sign_proposal(proposal_path: &Path, wallet: &str) -> Result<()> {
+    let mut proposal = load_proposal(proposal_path)?;
 
-    p::info(&format!("Signing proposal with wallet '{}'", wallet));
+    p::info(&format!("Signing proposal with '{}'", wallet));
 
-    let signature = multisig::generate_signature(wallet)?;
-    proposal.add_signature(wallet.to_string(), signature);
-
-    std::fs::write(proposal_path, serde_json::to_string_pretty(&proposal)?)?;
+    let signature = multisig::generate_proposal_signature(wallet, &proposal)?;
+    proposal.add_signature_checked(wallet.to_string(), signature)?;
+    save_proposal(proposal_path, &proposal)?;
 
     println!();
-    println!("  Status: {}", proposal.get_status());
-    println!(
-        "  Signatures: {}/{}",
-        proposal.signatures.len(),
-        proposal.threshold
-    );
-    println!();
-
     p::success("Proposal signed");
-
+    print_progress(&proposal);
     Ok(())
 }
 
-fn view_proposal(proposal_path: &std::path::Path) -> Result<()> {
-    let contents = std::fs::read_to_string(proposal_path)?;
-    let proposal: multisig::Proposal = serde_json::from_str(&contents)?;
+fn view_proposal(proposal_path: &Path) -> Result<()> {
+    let proposal = load_proposal(proposal_path)?;
 
     println!();
-    println!("{}", colored::Colorize::cyan("═══ PROPOSAL ═══"));
-    println!("ID:          {}", proposal.id);
-    println!("Network:     {}", proposal.network);
-    println!(
-        "Threshold:   {}/{}",
-        proposal.threshold,
-        proposal.signers.len()
+    p::header("Multi-Sig Proposal");
+    p::kv_accent("ID", &proposal.id);
+    p::kv("Network", &proposal.network);
+    p::kv(
+        "Threshold",
+        &format!("{}/{}", proposal.threshold, proposal.signers.len()),
     );
-    println!("Status:      {}", proposal.get_status());
-    println!("Created:     {}", proposal.created_at);
-    println!();
+    p::kv("Status", &proposal.get_status());
+    p::kv("Created", &proposal.created_at);
+    if let Some(title) = &proposal.metadata.title {
+        p::kv("Title", title);
+    }
+    if let Some(tx_type) = &proposal.metadata.transaction_type {
+        p::kv("Type", tx_type);
+    }
+    if let Some(xdr) = &proposal.transaction_xdr {
+        p::kv("Transaction", &preview(xdr, 40));
+    }
+    print_progress(&proposal);
 
-    println!("{}", colored::Colorize::cyan("═══ SIGNERS ═══"));
+    println!();
+    p::info("Signers");
     for (idx, signer) in proposal.signers.iter().enumerate() {
-        let signed = proposal.signatures.iter().any(|s| s.signer == *signer);
+        let signed = proposal.signatures.iter().any(|sig| sig.signer == *signer);
         let marker = if signed {
-            colored::Colorize::green("✓")
+            "signed".green()
         } else {
-            colored::Colorize::red("✗")
+            "pending".yellow()
         };
-        println!("  {} {}. {}", marker, idx + 1, signer);
+        println!("  {:>2}. {:<8} {}", idx + 1, marker, signer);
     }
 
     println!();
-    println!("{}", colored::Colorize::cyan("═══ SIGNATURES ═══"));
-    for sig in &proposal.signatures {
-        println!("  ✓ {}: {}", sig.signer, &sig.signature[..16]);
+    p::info("Signatures");
+    if proposal.signatures.is_empty() {
+        println!("  none");
+    } else {
+        for sig in &proposal.signatures {
+            println!("  {}: {}", sig.signer, preview(&sig.signature, 16));
+        }
     }
     println!();
-
     Ok(())
 }
 
-fn check_status(proposal_path: &std::path::Path) -> Result<()> {
-    let contents = std::fs::read_to_string(proposal_path)?;
-    let proposal: multisig::Proposal = serde_json::from_str(&contents)?;
-
-    let total = proposal.signers.len();
-    let signed = proposal.signatures.len();
-    let remaining = proposal.threshold as usize - signed;
+fn check_status(proposal_path: &Path) -> Result<()> {
+    let proposal = load_proposal(proposal_path)?;
+    let validation = multisig::validate_signatures(&proposal);
 
     println!();
-    println!("{}", colored::Colorize::cyan("═══ SIGNATURE STATUS ═══"));
-    println!("Progress: {}/{}", signed, proposal.threshold);
+    p::header("Signature Status");
+    print_progress(&proposal);
 
-    let percent = (signed as f32 / proposal.threshold as f32 * 100.0) as i32;
-    let filled = (percent / 10) as usize;
-    let empty = 10 - filled;
-
-    print!("  [");
-    for _ in 0..filled {
-        print!("{}", colored::Colorize::green("█"));
-    }
-    for _ in 0..empty {
-        print!("{}", colored::Colorize::red("░"));
-    }
-    println!("] {}%", percent);
-
-    println!();
-    if remaining > 0 {
-        println!("  {} signatures remaining", remaining);
-        println!();
-        for signer in &proposal.signers {
-            if !proposal.signatures.iter().any(|s| s.signer == *signer) {
-                println!("    ⏳ Waiting for: {}", signer);
-            }
-        }
+    if validation.ready {
+        p::success("All required signatures collected.");
     } else {
-        println!(
-            "  {} All signatures collected!",
-            colored::Colorize::green("✓")
+        p::info(&format!(
+            "{} signer(s) still needed: {}",
+            validation.missing_signers.len(),
+            validation.missing_signers.join(", ")
+        ));
+    }
+    println!();
+    Ok(())
+}
+
+fn verify_proposal(proposal_path: &Path) -> Result<()> {
+    let proposal = load_proposal(proposal_path)?;
+    let validation = multisig::validate_signatures(&proposal);
+
+    p::header("Signature Verification");
+    print_progress(&proposal);
+    p::kv("Valid signatures", &validation.valid_signatures.to_string());
+    p::kv("Required", &proposal.threshold.to_string());
+    p::kv("Ready", if validation.ready { "yes" } else { "no" });
+
+    if !validation.invalid_signers.is_empty() {
+        p::warn(&format!(
+            "Invalid signatures from: {}",
+            validation.invalid_signers.join(", ")
+        ));
+    }
+    if !validation.duplicate_signers.is_empty() {
+        p::warn(&format!(
+            "Duplicate signatures from: {}",
+            validation.duplicate_signers.join(", ")
+        ));
+    }
+    if !validation.missing_signers.is_empty() {
+        p::info(&format!(
+            "Pending signers: {}",
+            validation.missing_signers.join(", ")
+        ));
+    }
+
+    if !validation.invalid_signers.is_empty() || !validation.duplicate_signers.is_empty() {
+        anyhow::bail!("Proposal contains invalid signature data");
+    }
+    Ok(())
+}
+
+fn notify_signers(proposal_path: &Path, message: Option<String>) -> Result<()> {
+    let proposal = load_proposal(proposal_path)?;
+    notify_for_proposal(&proposal, message)
+}
+
+fn submit_proposal(proposal_path: &Path, network: &str) -> Result<()> {
+    let proposal = load_proposal(proposal_path)?;
+    let validation = multisig::validate_signatures(&proposal);
+
+    if !validation.ready {
+        anyhow::bail!(
+            "Not enough valid signatures: {}/{}",
+            validation.valid_signatures,
+            proposal.threshold
         );
     }
-    println!();
-
-    Ok(())
-}
-
-fn submit_proposal(proposal_path: &std::path::Path, network: &str) -> Result<()> {
-    let contents = std::fs::read_to_string(proposal_path)?;
-    let proposal: multisig::Proposal = serde_json::from_str(&contents)?;
-
-    if proposal.signatures.len() < proposal.threshold as usize {
+    if !validation.invalid_signers.is_empty() || !validation.duplicate_signers.is_empty() {
         anyhow::bail!(
-            "Not enough signatures: {}/{}",
-            proposal.signatures.len(),
-            proposal.threshold
+            "Proposal contains invalid or duplicate signatures. Run `starforge multisig verify`."
         );
     }
 
     p::info(&format!("Submitting proposal to {}", network));
-    println!(
-        "  Signatures: {}/{}",
-        proposal.signatures.len(),
-        proposal.threshold
+    p::kv(
+        "Signatures",
+        &format!("{}/{}", validation.valid_signatures, proposal.threshold),
     );
-    println!();
+    if let Some(xdr) = &proposal.transaction_xdr {
+        p::kv("Transaction", &preview(xdr, 40));
+    }
 
     p::success("Proposal submitted successfully");
     println!("  Hash: abc123def456...");
     println!();
-
     Ok(())
 }
 
-fn export_proposal(proposal_path: &std::path::Path, output: Option<PathBuf>) -> Result<()> {
-    let contents = std::fs::read_to_string(proposal_path)?;
-    let proposal: multisig::Proposal = serde_json::from_str(&contents)?;
-
+fn export_proposal(proposal_path: &Path, output: Option<PathBuf>) -> Result<()> {
+    let proposal = load_proposal(proposal_path)?;
     let output_file = output.unwrap_or_else(|| {
         PathBuf::from(format!(
             "proposal_export_{}.json",
@@ -284,89 +439,134 @@ fn export_proposal(proposal_path: &std::path::Path, output: Option<PathBuf>) -> 
         ))
     });
 
-    std::fs::write(&output_file, serde_json::to_string_pretty(&proposal)?)?;
-
+    save_proposal(&output_file, &proposal)?;
     p::success(&format!("Proposal exported: {}", output_file.display()));
-
     Ok(())
 }
 
-fn import_proposal(input_path: &std::path::Path, output: Option<PathBuf>) -> Result<()> {
-    let contents = std::fs::read_to_string(input_path)?;
-    let proposal: multisig::Proposal = serde_json::from_str(&contents)?;
-
+fn import_proposal(input_path: &Path, output: Option<PathBuf>) -> Result<()> {
+    let proposal = load_proposal(input_path)?;
+    validate_threshold(proposal.threshold, proposal.signers.len())?;
     let output_file =
         output.unwrap_or_else(|| PathBuf::from(format!("proposal_{}.json", uuid::Uuid::new_v4())));
 
-    std::fs::write(&output_file, serde_json::to_string_pretty(&proposal)?)?;
-
+    save_proposal(&output_file, &proposal)?;
     p::success(&format!("Proposal imported: {}", output_file.display()));
-
+    print_progress(&proposal);
     Ok(())
 }
 
 fn list_templates() -> Result<()> {
     println!();
-    println!("{}", colored::Colorize::cyan("═══ MULTI-SIG TEMPLATES ═══"));
-    println!();
-
-    let templates = vec![
-        ("escrow", "2-of-3 Escrow (buyer, seller, arbiter)"),
-        ("company", "3-of-5 Company Signers"),
-        ("dao", "5-of-9 DAO Treasury"),
-        ("vault", "2-of-2 Cold Storage Vault"),
-        ("payment", "1-of-2 Payment Authorization"),
-    ];
-
-    for (name, desc) in templates {
-        println!("  {} - {}", colored::Colorize::yellow(name), desc);
+    p::header("Multi-Sig Templates");
+    for template in multisig::common_templates() {
+        println!(
+            "  {} - {} [{}/{}]",
+            template.name.yellow(),
+            template.description,
+            template.threshold,
+            template.signers.len()
+        );
     }
-
     println!();
-    println!("Usage: starforge multisig from-template <template> --output <file>");
+    println!("Usage: starforge multisig from-template <template> <file> --network testnet");
     println!();
-
     Ok(())
 }
 
-fn from_template(template: &str, output: &std::path::Path) -> Result<()> {
+fn from_template(template: &str, output: &Path, network: &str) -> Result<()> {
     p::info(&format!("Creating proposal from template '{}'", template));
 
-    let (threshold, signers, name) = match template {
-        "escrow" => (2, vec!["buyer", "seller", "arbiter"], "2-of-3 Escrow"),
-        "company" => (
-            3,
-            vec!["ceo", "cfo", "board1", "board2", "board3"],
-            "3-of-5 Company",
-        ),
-        "dao" => (
-            5,
-            vec![
-                "member1", "member2", "member3", "member4", "member5", "member6", "member7",
-                "member8", "member9",
-            ],
-            "5-of-9 DAO Treasury",
-        ),
-        "vault" => (2, vec!["key1", "key2"], "2-of-2 Vault"),
-        "payment" => (1, vec!["approver1", "approver2"], "1-of-2 Payment"),
-        _ => anyhow::bail!("Unknown template: {}", template),
-    };
-
-    let proposal = multisig::Proposal::new(
-        threshold,
-        signers.iter().map(|s| s.to_string()).collect(),
-        "testnet".to_string(),
-    );
-
-    std::fs::write(output, serde_json::to_string_pretty(&proposal)?)?;
+    let proposal = multisig::proposal_from_template(template, network.to_string())?;
+    save_proposal(output, &proposal)?;
 
     println!();
-    println!("  Template: {}", name);
-    println!("  Threshold: {}/{}", threshold, signers.len());
-    println!("  Signers: {}", signers.join(", "));
-    println!();
-
     p::success(&format!("Proposal created: {}", output.display()));
+    p::kv(
+        "Template",
+        proposal.metadata.title.as_deref().unwrap_or(template),
+    );
+    p::kv(
+        "Threshold",
+        &format!("{}/{}", proposal.threshold, proposal.signers.len()),
+    );
+    p::kv("Signers", &proposal.signers.join(", "));
+    print_progress(&proposal);
+    Ok(())
+}
 
+fn load_proposal(path: &Path) -> Result<multisig::Proposal> {
+    let contents = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
+fn save_proposal(path: &Path, proposal: &multisig::Proposal) -> Result<()> {
+    std::fs::write(path, serde_json::to_string_pretty(proposal)?)?;
+    Ok(())
+}
+
+fn parse_signers(signers: &str) -> Vec<String> {
+    signers
+        .split(',')
+        .map(|signer| signer.trim().to_string())
+        .filter(|signer| !signer.is_empty())
+        .collect()
+}
+
+fn validate_threshold(threshold: u32, signer_count: usize) -> Result<()> {
+    if threshold == 0 {
+        anyhow::bail!("Threshold must be greater than zero");
+    }
+    if signer_count == 0 {
+        anyhow::bail!("At least one signer is required");
+    }
+    if threshold as usize > signer_count {
+        anyhow::bail!("Threshold cannot exceed number of signers");
+    }
+    Ok(())
+}
+
+fn print_progress(proposal: &multisig::Proposal) {
+    let progress = multisig::calculate_progress(proposal);
+    println!(
+        "  Progress: {}",
+        multisig::render_progress_bar(&progress, 20).cyan()
+    );
+}
+
+fn preview(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let prefix: String = value.chars().take(max_chars).collect();
+    format!("{}...", prefix)
+}
+
+fn notify_for_proposal(proposal: &multisig::Proposal, message: Option<String>) -> Result<()> {
+    let progress = multisig::calculate_progress(proposal);
+    if progress.pending_signers.is_empty() {
+        p::info("No pending signers to notify.");
+        return Ok(());
+    }
+
+    let default_message = format!(
+        "Signature requested for proposal {} ({}/{})",
+        proposal.id, progress.signed, progress.required
+    );
+    let mut data = HashMap::new();
+    data.insert("proposal_id".to_string(), proposal.id.clone());
+    data.insert("network".to_string(), proposal.network.clone());
+    data.insert("threshold".to_string(), proposal.threshold.to_string());
+    data.insert(
+        "pending_signers".to_string(),
+        progress.pending_signers.join(","),
+    );
+    data.insert("message".to_string(), message.unwrap_or(default_message));
+
+    notifications::send_notification("multisig_signature_request", &data, "medium")?;
+    p::success(&format!(
+        "Queued signature request notification for {} signer(s)",
+        progress.pending_signers.len()
+    ));
     Ok(())
 }

--- a/src/utils/multisig_builder.rs
+++ b/src/utils/multisig_builder.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,6 +14,10 @@ pub struct Proposal {
     pub created_at: String,
     pub expires_at: Option<String>,
     pub metadata: ProposalMetadata,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_xdr: Option<String>,
+    #[serde(default)]
+    pub events: Vec<ProposalEvent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +34,43 @@ pub struct ProposalMetadata {
     pub transaction_type: Option<String>,
     pub amount: Option<f64>,
     pub recipient: Option<String>,
+    #[serde(default)]
+    pub template: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposalEvent {
+    pub event_type: String,
+    pub message: String,
+    pub at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignatureProgress {
+    pub signed: u32,
+    pub required: u32,
+    pub total_signers: u32,
+    pub percent: u32,
+    pub ready: bool,
+    pub pending_signers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignatureValidationReport {
+    pub valid_signatures: u32,
+    pub invalid_signers: Vec<String>,
+    pub duplicate_signers: Vec<String>,
+    pub missing_signers: Vec<String>,
+    pub ready: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultisigTemplate {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub threshold: u32,
+    pub signers: Vec<&'static str>,
+    pub transaction_type: &'static str,
 }
 
 impl Proposal {
@@ -47,16 +89,39 @@ impl Proposal {
                 transaction_type: None,
                 amount: None,
                 recipient: None,
+                template: None,
             },
+            transaction_xdr: None,
+            events: vec![ProposalEvent {
+                event_type: "created".to_string(),
+                message: "Proposal created".to_string(),
+                at: Utc::now().to_rfc3339(),
+            }],
         }
     }
 
     pub fn add_signature(&mut self, signer: String, signature: String) {
         self.signatures.push(Signature {
-            signer,
+            signer: signer.clone(),
             signature,
             signed_at: Utc::now().to_rfc3339(),
         });
+        self.events.push(ProposalEvent {
+            event_type: "signed".to_string(),
+            message: format!("Signature collected from {}", signer),
+            at: Utc::now().to_rfc3339(),
+        });
+    }
+
+    pub fn add_signature_checked(&mut self, signer: String, signature: String) -> Result<()> {
+        if !self.signers.contains(&signer) {
+            anyhow::bail!("Signer '{}' is not authorized for this proposal", signer);
+        }
+        if self.signatures.iter().any(|sig| sig.signer == signer) {
+            anyhow::bail!("Signer '{}' has already signed this proposal", signer);
+        }
+        self.add_signature(signer, signature);
+        Ok(())
     }
 
     pub fn is_complete(&self) -> bool {
@@ -84,6 +149,191 @@ impl Proposal {
     }
 }
 
+pub fn common_templates() -> Vec<MultisigTemplate> {
+    vec![
+        MultisigTemplate {
+            name: "escrow",
+            description: "2-of-3 Escrow (buyer, seller, arbiter)",
+            threshold: 2,
+            signers: vec!["buyer", "seller", "arbiter"],
+            transaction_type: "escrow_release",
+        },
+        MultisigTemplate {
+            name: "company",
+            description: "3-of-5 Company treasury approval",
+            threshold: 3,
+            signers: vec!["ceo", "cfo", "legal", "ops", "board"],
+            transaction_type: "treasury_transfer",
+        },
+        MultisigTemplate {
+            name: "dao",
+            description: "5-of-9 DAO treasury authorization",
+            threshold: 5,
+            signers: vec![
+                "member1", "member2", "member3", "member4", "member5", "member6", "member7",
+                "member8", "member9",
+            ],
+            transaction_type: "dao_treasury",
+        },
+        MultisigTemplate {
+            name: "vault",
+            description: "2-of-2 Cold storage vault",
+            threshold: 2,
+            signers: vec!["primary_key", "recovery_key"],
+            transaction_type: "vault_release",
+        },
+        MultisigTemplate {
+            name: "payment",
+            description: "1-of-2 Payment authorization",
+            threshold: 1,
+            signers: vec!["requester", "approver"],
+            transaction_type: "payment",
+        },
+    ]
+}
+
+pub fn template_by_name(name: &str) -> Option<MultisigTemplate> {
+    common_templates()
+        .into_iter()
+        .find(|template| template.name.eq_ignore_ascii_case(name))
+}
+
+pub fn proposal_from_template(template: &str, network: String) -> Result<Proposal> {
+    let template = template_by_name(template)
+        .ok_or_else(|| anyhow::anyhow!("Unknown multi-sig template: {}", template))?;
+    let mut proposal = Proposal::new(
+        template.threshold,
+        template
+            .signers
+            .iter()
+            .map(|signer| signer.to_string())
+            .collect(),
+        network,
+    );
+    proposal.metadata.title = Some(template.description.to_string());
+    proposal.metadata.transaction_type = Some(template.transaction_type.to_string());
+    proposal.metadata.template = Some(template.name.to_string());
+    proposal.events.push(ProposalEvent {
+        event_type: "template_applied".to_string(),
+        message: format!("Applied '{}' template", template.name),
+        at: Utc::now().to_rfc3339(),
+    });
+    Ok(proposal)
+}
+
+pub fn calculate_progress(proposal: &Proposal) -> SignatureProgress {
+    let validation = validate_signatures(proposal);
+    let signed = validation.valid_signatures;
+    let required = proposal.threshold;
+    let percent = if required == 0 {
+        0
+    } else {
+        ((signed.min(required) as f64 / required as f64) * 100.0).round() as u32
+    };
+
+    SignatureProgress {
+        signed,
+        required,
+        total_signers: proposal.signers.len() as u32,
+        percent,
+        ready: signed >= required && required > 0,
+        pending_signers: validation.missing_signers,
+    }
+}
+
+pub fn render_progress_bar(progress: &SignatureProgress, width: usize) -> String {
+    let width = width.max(1);
+    let filled = ((progress.percent.min(100) as usize * width) + 50) / 100;
+    let filled = filled.min(width);
+    let empty = width - filled;
+    format!(
+        "[{}{}] {}% ({}/{})",
+        "#".repeat(filled),
+        ".".repeat(empty),
+        progress.percent,
+        progress.signed,
+        progress.required
+    )
+}
+
+pub fn proposal_signature_payload(proposal: &Proposal) -> String {
+    let metadata = serde_json::to_string(&proposal.metadata).unwrap_or_default();
+    format!(
+        "{}|{}|{}|{}|{}|{}",
+        proposal.id,
+        proposal.network,
+        proposal.threshold,
+        proposal.signers.join(","),
+        proposal.transaction_xdr.as_deref().unwrap_or(""),
+        metadata
+    )
+}
+
+pub fn generate_signature_for_payload(signer: &str, message: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(signer.as_bytes());
+    hasher.update(b":");
+    hasher.update(message.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+pub fn generate_proposal_signature(signer: &str, proposal: &Proposal) -> Result<String> {
+    Ok(generate_signature_for_payload(
+        signer,
+        &proposal_signature_payload(proposal),
+    ))
+}
+
+pub fn verify_proposal_signature(proposal: &Proposal, signature: &Signature) -> bool {
+    if !proposal.signers.contains(&signature.signer) {
+        return false;
+    }
+
+    let payload = proposal_signature_payload(proposal);
+    verify_signature(&signature.signer, &signature.signature, &payload)
+        || generate_signature(&signature.signer)
+            .map(|legacy| legacy == signature.signature)
+            .unwrap_or(false)
+}
+
+pub fn validate_signatures(proposal: &Proposal) -> SignatureValidationReport {
+    let mut valid = HashSet::new();
+    let mut seen = HashSet::new();
+    let mut invalid_signers = Vec::new();
+    let mut duplicate_signers = Vec::new();
+
+    for signature in &proposal.signatures {
+        if !seen.insert(signature.signer.clone()) {
+            duplicate_signers.push(signature.signer.clone());
+            continue;
+        }
+
+        if verify_proposal_signature(proposal, signature) {
+            valid.insert(signature.signer.clone());
+        } else {
+            invalid_signers.push(signature.signer.clone());
+        }
+    }
+
+    let missing_signers = proposal
+        .signers
+        .iter()
+        .filter(|signer| !valid.contains(*signer))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let valid_signatures = valid.len() as u32;
+    SignatureValidationReport {
+        valid_signatures,
+        invalid_signers,
+        duplicate_signers,
+        missing_signers,
+        ready: valid_signatures >= proposal.threshold && proposal.threshold > 0,
+    }
+}
+
 pub fn generate_signature(wallet: &str) -> Result<String> {
     use hex;
     use sha2::{Digest, Sha256};
@@ -96,15 +346,22 @@ pub fn generate_signature(wallet: &str) -> Result<String> {
 }
 
 pub fn verify_signature(signer: &str, signature: &str, message: &str) -> bool {
-    use hex;
     use sha2::{Digest, Sha256};
 
     let mut hasher = Sha256::new();
+    hasher.update(signer.as_bytes());
+    hasher.update(b":");
     hasher.update(message.as_bytes());
     let result = hasher.finalize();
     let expected = hex::encode(result);
 
-    expected == signature
+    if expected == signature {
+        return true;
+    }
+
+    let mut legacy_hasher = Sha256::new();
+    legacy_hasher.update(message.as_bytes());
+    hex::encode(legacy_hasher.finalize()) == signature
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/tests/multisig_builder_ui.rs
+++ b/tests/multisig_builder_ui.rs
@@ -1,0 +1,92 @@
+use starforge::utils::multisig_builder::{
+    calculate_progress, common_templates, generate_proposal_signature, proposal_from_template,
+    render_progress_bar, validate_signatures, Proposal,
+};
+
+#[test]
+fn templates_create_proposals_with_metadata() {
+    let templates = common_templates();
+    assert!(templates.iter().any(|template| template.name == "escrow"));
+
+    let proposal = proposal_from_template("escrow", "testnet".to_string()).unwrap();
+    assert_eq!(proposal.threshold, 2);
+    assert_eq!(proposal.signers, vec!["buyer", "seller", "arbiter"]);
+    assert_eq!(proposal.network, "testnet");
+    assert_eq!(proposal.metadata.template.as_deref(), Some("escrow"));
+    assert_eq!(
+        proposal.metadata.transaction_type.as_deref(),
+        Some("escrow_release")
+    );
+}
+
+#[test]
+fn progress_tracks_valid_signatures_and_pending_signers() {
+    let mut proposal = Proposal::new(
+        2,
+        vec!["alice".to_string(), "bob".to_string(), "carol".to_string()],
+        "testnet".to_string(),
+    );
+
+    let signature = generate_proposal_signature("alice", &proposal).unwrap();
+    proposal
+        .add_signature_checked("alice".to_string(), signature)
+        .unwrap();
+
+    let progress = calculate_progress(&proposal);
+    assert_eq!(progress.signed, 1);
+    assert_eq!(progress.required, 2);
+    assert_eq!(progress.percent, 50);
+    assert!(!progress.ready);
+    assert_eq!(progress.pending_signers, vec!["bob", "carol"]);
+
+    let bar = render_progress_bar(&progress, 10);
+    assert_eq!(bar, "[#####.....] 50% (1/2)");
+}
+
+#[test]
+fn signature_validation_rejects_invalid_and_duplicate_signatures() {
+    let mut proposal = Proposal::new(
+        2,
+        vec!["alice".to_string(), "bob".to_string()],
+        "testnet".to_string(),
+    );
+
+    let alice_signature = generate_proposal_signature("alice", &proposal).unwrap();
+    proposal
+        .add_signature_checked("alice".to_string(), alice_signature)
+        .unwrap();
+    assert!(proposal
+        .add_signature_checked("alice".to_string(), "duplicate".to_string())
+        .is_err());
+
+    proposal.add_signature("bob".to_string(), "not-a-valid-signature".to_string());
+
+    let validation = validate_signatures(&proposal);
+    assert_eq!(validation.valid_signatures, 1);
+    assert_eq!(validation.invalid_signers, vec!["bob"]);
+    assert_eq!(validation.missing_signers, vec!["bob"]);
+    assert!(!validation.ready);
+}
+
+#[test]
+fn validation_marks_ready_when_threshold_is_met() {
+    let mut proposal = Proposal::new(
+        2,
+        vec!["alice".to_string(), "bob".to_string(), "carol".to_string()],
+        "testnet".to_string(),
+    );
+
+    let alice_signature = generate_proposal_signature("alice", &proposal).unwrap();
+    proposal
+        .add_signature_checked("alice".to_string(), alice_signature)
+        .unwrap();
+    let bob_signature = generate_proposal_signature("bob", &proposal).unwrap();
+    proposal
+        .add_signature_checked("bob".to_string(), bob_signature)
+        .unwrap();
+
+    let validation = validate_signatures(&proposal);
+    assert_eq!(validation.valid_signatures, 2);
+    assert!(validation.ready);
+    assert_eq!(calculate_progress(&proposal).percent, 100);
+}


### PR DESCRIPTION
## Description

Implements an interactive multi-signature transaction builder for teams, with proposal creation, visual signature progress, signature verification, JSON sharing, common templates, and notification requests for pending signers.

Closes #343

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made

- Added `starforge multisig wizard` interactive proposal flow
- Added visual signature progress tracking for proposal status/view flows
- Added proposal metadata, transaction XDR support, event history, and backward-compatible JSON fields
- Added signature payload generation, duplicate checks, validation reports, and `multisig verify`
- Added `multisig notify` to queue signature request notifications for pending signers
- Added common templates for escrow, company treasury, DAO, vault, and payment workflows
- Updated command reference docs and added focused tests

## Testing

```bash
cargo check
cargo test --test multisig_builder_ui -- --nocapture
cargo test multisig_builder --lib -- --nocapture
```

## Test Coverage

- Happy path: template proposal creation, progress tracking, valid signature collection, readiness detection
- Edge cases: duplicate signatures rejected, pending signer tracking
- Error handling: invalid signatures reported and excluded from readiness

## Breaking Changes

None. Existing proposal JSON remains backward-compatible through serde defaults.

## Documentation

Updated `docs/COMMAND_REFERENCE.md` with the new `multisig` commands and examples.
