### PR TITLE
feat: add contract security audit integration

### DIFF
--- a/docs/COMMAND_REFERENCE.md
+++ b/docs/COMMAND_REFERENCE.md
@@ -153,6 +153,28 @@ Fixture suites support named storage fixtures, mocked contract calls, and assert
 
 ---
 
+## `security`
+
+| Subcommand | Purpose |
+|------------|---------|
+| `audit <PATH>` | Run built-in Soroban analysis plus optional Slither/Mythril integrations |
+| `audit --format json\|html --out <FILE>` | Generate machine-readable or HTML audit reports |
+| `audit --ci --min-score <N>` | Fail when the audit score is below the CI threshold |
+| `audit --ci-workflow-out <FILE>` | Generate a GitHub Actions workflow for security audits |
+| `audit --track` | Create remediation tracker items for findings |
+| `remediation list` | Review tracked audit and pentest remediation items |
+
+```bash
+starforge security audit ./contracts/token/src/lib.rs --format html --out audit.html
+starforge security audit ./contracts/token/src/lib.rs --ci --min-score 85
+starforge security audit ./contracts/token/src/lib.rs \
+  --ci-workflow-out .github/workflows/starforge-security.yml
+```
+
+External tools are optional. StarForge runs built-in Soroban heuristics every time and records whether Slither/Mythril were completed, failed, skipped, or unavailable.
+
+---
+
 ## `upgrade`
 
 | Subcommand | Purpose |

--- a/src/commands/security.rs
+++ b/src/commands/security.rs
@@ -1,9 +1,9 @@
 use crate::utils::print as p;
 use crate::utils::security::{
-    apply_hardening, default_rules, evaluate_event, format_report, generate_hardening_report,
-    run_audit, run_checklist, run_pentest, track_findings, validate_security, write_report,
-    AnomalyDetector, AuditConfig, HardeningOptions, IncidentResponse, IncidentStore,
-    RemediationStatus, ThreatFeed,
+    apply_hardening, default_rules, evaluate_event, format_html_report, format_report,
+    generate_github_actions_workflow, generate_hardening_report, run_audit, run_checklist,
+    run_pentest, track_findings, validate_security, write_report, AnomalyDetector, AuditConfig,
+    HardeningOptions, IncidentResponse, IncidentStore, RemediationStatus, ThreatFeed,
 };
 use crate::utils::stream::{EventStreamFilters, SorobanEventStream};
 use crate::utils::{config, notifications, soroban};
@@ -49,7 +49,7 @@ pub struct AuditArgs {
     /// Run Mythril if installed
     #[arg(long, default_value = "true")]
     pub mythril: bool,
-    /// Output format: text or json
+    /// Output format: text, json, or html
     #[arg(long, default_value = "text")]
     pub format: String,
     /// Save report to file instead of stdout
@@ -58,6 +58,15 @@ pub struct AuditArgs {
     /// CI mode: exit non-zero if score is below threshold (0-100)
     #[arg(long)]
     pub min_score: Option<f64>,
+    /// CI mode: default minimum score to 80 and fail on unmet threshold
+    #[arg(long, default_value_t = false)]
+    pub ci: bool,
+    /// Write a GitHub Actions workflow that runs this audit
+    #[arg(long)]
+    pub ci_workflow_out: Option<PathBuf>,
+    /// Track findings in the remediation tracker
+    #[arg(long, default_value_t = false)]
+    pub track: bool,
 }
 
 #[derive(Args)]
@@ -388,6 +397,7 @@ fn handle_audit(args: AuditArgs) -> Result<()> {
     };
 
     let result = run_audit(&args.path, &cfg)?;
+    let min_score = args.min_score.or_else(|| args.ci.then_some(80.0));
 
     let score_label = match result.score as u32 {
         90..=100 => "Excellent",
@@ -398,6 +408,7 @@ fn handle_audit(args: AuditArgs) -> Result<()> {
 
     p::separator();
     p::kv("Tools used", &result.tools_used.join(", "));
+    p::kv("CI ready", if result.ci_passed { "yes" } else { "no" });
     p::kv(
         "Security score",
         &format!("{:.1}/100  ({})", result.score, score_label),
@@ -407,6 +418,20 @@ fn handle_audit(args: AuditArgs) -> Result<()> {
     p::kv("Medium  ", &result.summary.medium.to_string());
     p::kv("Low     ", &result.summary.low.to_string());
     p::kv("Info    ", &result.summary.info.to_string());
+
+    println!();
+    p::header("Tool Status");
+    for tool in &result.tool_statuses {
+        let detail = tool
+            .message
+            .as_deref()
+            .map(|message| format!(" - {}", message))
+            .unwrap_or_default();
+        println!(
+            "  {}: {} (findings: {}){}",
+            tool.tool, tool.status, tool.findings, detail
+        );
+    }
 
     if !result.findings.is_empty() {
         println!();
@@ -431,6 +456,34 @@ fn handle_audit(args: AuditArgs) -> Result<()> {
         p::success("No security issues found.");
     }
 
+    if args.track {
+        let tracking_findings: Vec<_> = result
+            .findings
+            .iter()
+            .map(|finding| {
+                (
+                    finding.title.clone(),
+                    finding.severity.clone(),
+                    finding.description.clone(),
+                    finding.remediation.clone(),
+                )
+            })
+            .collect();
+        let created = track_findings("audit", &tracking_findings)?;
+        if !created.is_empty() {
+            p::info(&format!(
+                "Created {} remediation tracking item(s)",
+                created.len()
+            ));
+        }
+    }
+
+    if let Some(path) = &args.ci_workflow_out {
+        let workflow = generate_github_actions_workflow(&args.path, min_score.unwrap_or(80.0));
+        fs::write(path, workflow)?;
+        p::kv("CI workflow", &path.display().to_string());
+    }
+
     match args.format.as_str() {
         "json" => {
             let json = serde_json::to_string_pretty(&result)?;
@@ -441,16 +494,31 @@ fn handle_audit(args: AuditArgs) -> Result<()> {
                 println!("{}", json);
             }
         }
-        _ => {
+        "html" => {
+            let html = format_html_report(&result);
+            if let Some(out) = &args.out {
+                fs::write(out, &html)?;
+                p::kv("Report saved", &out.display().to_string());
+            } else {
+                println!("{}", html);
+            }
+        }
+        "text" => {
             if let Some(out) = &args.out {
                 let text = format_report(&result);
                 fs::write(out, &text)?;
                 p::kv("Report saved", &out.display().to_string());
             }
         }
+        _ => {
+            anyhow::bail!(
+                "Unsupported audit format '{}'. Use text, json, or html.",
+                args.format
+            );
+        }
     }
 
-    if let Some(min) = args.min_score {
+    if let Some(min) = min_score {
         if result.score < min {
             anyhow::bail!(
                 "Security score {:.1} is below required minimum {:.1}",
@@ -506,7 +574,11 @@ fn handle_pentest(args: PentestArgs) -> Result<()> {
     println!();
 
     for r in &report.results {
-        let icon = if r.exploited { "✗".red() } else { "✓".green() };
+        let icon = if r.exploited {
+            "✗".red()
+        } else {
+            "✓".green()
+        };
         println!(
             "  {} [{}] {} ({})",
             icon,

--- a/src/utils/security/audit.rs
+++ b/src/utils/security/audit.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::path::Path;
 use std::process::Command;
 
@@ -31,7 +32,11 @@ pub struct AuditResult {
     pub score: f64,
     pub findings: Vec<VulnerabilityFinding>,
     pub tools_used: Vec<String>,
+    #[serde(default)]
+    pub tool_statuses: Vec<AuditToolStatus>,
     pub summary: AuditSummary,
+    #[serde(default)]
+    pub ci_passed: bool,
 }
 
 pub struct AuditConfig {
@@ -39,36 +44,61 @@ pub struct AuditConfig {
     pub run_mythril: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditToolStatus {
+    pub tool: String,
+    pub available: bool,
+    pub executed: bool,
+    pub status: String,
+    pub command: Option<String>,
+    pub findings: u32,
+    pub message: Option<String>,
+}
+
 pub fn run_audit(path: &Path, config: &AuditConfig) -> Result<AuditResult> {
     let mut findings = Vec::new();
     let mut tools_used = Vec::new();
+    let mut tool_statuses = Vec::new();
 
     let builtin = run_builtin_analysis(path)?;
+    let builtin_count = builtin.len() as u32;
     findings.extend(builtin);
     tools_used.push("starforge-builtin".to_string());
+    tool_statuses.push(AuditToolStatus {
+        tool: "starforge-builtin".to_string(),
+        available: true,
+        executed: true,
+        status: "completed".to_string(),
+        command: None,
+        findings: builtin_count,
+        message: Some("Built-in Soroban heuristics completed".to_string()),
+    });
 
-    if config.run_slither && is_tool_available("slither") {
-        match run_slither(path) {
-            Ok(mut sf) => {
-                findings.append(&mut sf);
-                tools_used.push("slither".to_string());
-            }
-            Err(e) => eprintln!("Warning: Slither failed: {}", e),
-        }
-    }
+    collect_external_tool(
+        "slither",
+        &["STARFORGE_SLITHER_CMD"],
+        config.run_slither,
+        path,
+        run_slither,
+        &mut findings,
+        &mut tools_used,
+        &mut tool_statuses,
+    );
 
-    if config.run_mythril && is_tool_available("myth") {
-        match run_mythril(path) {
-            Ok(mut mf) => {
-                findings.append(&mut mf);
-                tools_used.push("mythril".to_string());
-            }
-            Err(e) => eprintln!("Warning: Mythril failed: {}", e),
-        }
-    }
+    collect_external_tool(
+        "mythril",
+        &["STARFORGE_MYTHRIL_CMD", "STARFORGE_MYTH_CMD"],
+        config.run_mythril,
+        path,
+        run_mythril,
+        &mut findings,
+        &mut tools_used,
+        &mut tool_statuses,
+    );
 
     let summary = compute_summary(&findings);
     let score = compute_score(&summary);
+    let ci_passed = score >= 80.0 && summary.critical == 0;
 
     Ok(AuditResult {
         timestamp: Utc::now().to_rfc3339(),
@@ -76,27 +106,129 @@ pub fn run_audit(path: &Path, config: &AuditConfig) -> Result<AuditResult> {
         score,
         findings,
         tools_used,
+        tool_statuses,
         summary,
+        ci_passed,
     })
 }
 
+fn collect_external_tool(
+    tool: &str,
+    env_vars: &[&str],
+    enabled: bool,
+    path: &Path,
+    runner: fn(&Path, &str) -> Result<Vec<VulnerabilityFinding>>,
+    findings: &mut Vec<VulnerabilityFinding>,
+    tools_used: &mut Vec<String>,
+    tool_statuses: &mut Vec<AuditToolStatus>,
+) {
+    if !enabled {
+        tool_statuses.push(skipped_tool_status(tool, "Disabled by audit configuration"));
+        return;
+    }
+
+    let Some(command) = resolve_tool(default_command_for(tool), env_vars) else {
+        tool_statuses.push(skipped_tool_status(
+            tool,
+            &format!(
+                "{} not found. Install it or configure {}.",
+                tool,
+                env_vars.join("/")
+            ),
+        ));
+        return;
+    };
+
+    match runner(path, &command) {
+        Ok(mut tool_findings) => {
+            let count = tool_findings.len() as u32;
+            findings.append(&mut tool_findings);
+            tools_used.push(tool.to_string());
+            tool_statuses.push(AuditToolStatus {
+                tool: tool.to_string(),
+                available: true,
+                executed: true,
+                status: "completed".to_string(),
+                command: Some(command),
+                findings: count,
+                message: None,
+            });
+        }
+        Err(err) => {
+            tool_statuses.push(AuditToolStatus {
+                tool: tool.to_string(),
+                available: true,
+                executed: true,
+                status: "failed".to_string(),
+                command: Some(command),
+                findings: 0,
+                message: Some(err.to_string()),
+            });
+        }
+    }
+}
+
+fn default_command_for(tool: &str) -> &str {
+    match tool {
+        "mythril" => "myth",
+        other => other,
+    }
+}
+
+fn skipped_tool_status(tool: &str, message: &str) -> AuditToolStatus {
+    AuditToolStatus {
+        tool: tool.to_string(),
+        available: false,
+        executed: false,
+        status: "skipped".to_string(),
+        command: None,
+        findings: 0,
+        message: Some(message.to_string()),
+    }
+}
+
+fn resolve_tool(default_command: &str, env_vars: &[&str]) -> Option<String> {
+    for env_var in env_vars {
+        if let Ok(command) = env::var(env_var) {
+            let command = command.trim();
+            if !command.is_empty() {
+                return Some(command.to_string());
+            }
+        }
+    }
+
+    if is_tool_available(default_command) {
+        Some(default_command.to_string())
+    } else {
+        None
+    }
+}
+
 fn is_tool_available(tool: &str) -> bool {
-    Command::new("which")
+    let probe = if cfg!(windows) { "where" } else { "which" };
+    Command::new(probe)
         .arg(tool)
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
 }
 
-fn run_slither(path: &Path) -> Result<Vec<VulnerabilityFinding>> {
-    let output = Command::new("slither")
+fn run_slither(path: &Path, command: &str) -> Result<Vec<VulnerabilityFinding>> {
+    let output = Command::new(command)
         .arg(path)
         .arg("--json")
         .arg("-")
         .output()?;
 
-    let json_str = String::from_utf8_lossy(&output.stdout);
-    parse_slither_output(&json_str)
+    if !output.status.success() {
+        anyhow::bail!(
+            "Slither exited with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    parse_slither_output(&String::from_utf8_lossy(&output.stdout))
 }
 
 fn parse_slither_output(json_str: &str) -> Result<Vec<VulnerabilityFinding>> {
@@ -166,30 +298,37 @@ fn parse_slither_output(json_str: &str) -> Result<Vec<VulnerabilityFinding>> {
 fn slither_remediation(check: &str) -> String {
     match check {
         "reentrancy-eth" | "reentrancy-no-eth" => {
-            "Use the checks-effects-interactions pattern or a reentrancy guard.".to_string()
+            "Use checks-effects-interactions or add a reentrancy guard.".to_string()
         }
         "uninitialized-state" | "uninitialized-storage" => {
-            "Initialize all state variables before use.".to_string()
+            "Initialize all state before it is read.".to_string()
         }
         "integer-overflow" | "integer-underflow" => {
-            "Use checked arithmetic operations.".to_string()
+            "Use checked arithmetic operations for amount and counter math.".to_string()
         }
-        "arbitrary-send-eth" => "Validate the recipient address before sending funds.".to_string(),
-        "suicidal" => "Remove or restrict access to self-destruct functionality.".to_string(),
+        "arbitrary-send-eth" => "Validate the recipient before transferring funds.".to_string(),
+        "suicidal" => "Remove or strictly restrict destructive operations.".to_string(),
         _ => format!("Review and fix the '{}' vulnerability pattern.", check),
     }
 }
 
-fn run_mythril(path: &Path) -> Result<Vec<VulnerabilityFinding>> {
-    let output = Command::new("myth")
+fn run_mythril(path: &Path, command: &str) -> Result<Vec<VulnerabilityFinding>> {
+    let output = Command::new(command)
         .arg("analyze")
         .arg(path)
         .arg("--output")
         .arg("json")
         .output()?;
 
-    let json_str = String::from_utf8_lossy(&output.stdout);
-    parse_mythril_output(&json_str)
+    if !output.status.success() {
+        anyhow::bail!(
+            "Mythril exited with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    parse_mythril_output(&String::from_utf8_lossy(&output.stdout))
 }
 
 fn parse_mythril_output(json_str: &str) -> Result<Vec<VulnerabilityFinding>> {
@@ -241,10 +380,23 @@ fn parse_mythril_output(json_str: &str) -> Result<Vec<VulnerabilityFinding>> {
             description,
             location,
             tool: "mythril".to_string(),
-            remediation: "Review the Mythril finding and apply the recommended fix.".to_string(),
+            remediation: mythril_remediation(&issue.title),
         });
     }
     Ok(findings)
+}
+
+fn mythril_remediation(title: &str) -> String {
+    let lower = title.to_ascii_lowercase();
+    if lower.contains("reentrancy") {
+        "Move state updates before external calls and add explicit authorization.".to_string()
+    } else if lower.contains("overflow") || lower.contains("underflow") {
+        "Use checked or saturating arithmetic for amount and counter updates.".to_string()
+    } else if lower.contains("access") || lower.contains("authorization") {
+        "Require the expected signer or admin before privileged logic.".to_string()
+    } else {
+        "Review the Mythril finding and apply the recommended fix.".to_string()
+    }
 }
 
 fn run_builtin_analysis(path: &Path) -> Result<Vec<VulnerabilityFinding>> {
@@ -256,7 +408,7 @@ fn run_builtin_analysis(path: &Path) -> Result<Vec<VulnerabilityFinding>> {
             findings.push(VulnerabilityFinding {
                 id: format!("SF-{}", item.id.to_uppercase()),
                 title: item.title.clone(),
-                severity: item.severity.clone(),
+                severity: normalize_severity(&item.severity).to_string(),
                 description: item.description.clone(),
                 location: Some(path.to_string_lossy().to_string()),
                 tool: "starforge-builtin".to_string(),
@@ -269,20 +421,32 @@ fn run_builtin_analysis(path: &Path) -> Result<Vec<VulnerabilityFinding>> {
 
 fn builtin_remediation(id: &str) -> String {
     match id {
-        "auth_check" => {
-            "Add authorization checks using require_auth() before sensitive operations.".to_string()
+        "auth_check" | "auth-missing" => {
+            "Add require_auth() before sensitive state changes.".to_string()
         }
-        "overflow" => {
-            "Use checked arithmetic operations (checked_add, checked_sub, etc.).".to_string()
+        "overflow" | "unchecked-arithmetic" => {
+            "Use checked_add, checked_sub, checked_mul, or saturating operations.".to_string()
         }
-        "panic" => {
-            "Replace expect()/unwrap() with proper error handling using Result<T, E>.".to_string()
+        "panic" | "unsafe-unwrap" => {
+            "Replace unwrap/expect with explicit Result or fallback handling.".to_string()
         }
-        "reentrancy" => {
-            "Avoid calling external contracts mid-function; emit events after state changes."
-                .to_string()
+        "reentrancy" | "reentrancy-risk" => {
+            "Avoid external calls before state changes and emit events after mutations.".to_string()
+        }
+        "no-upgrade-guard" => {
+            "Require admin or governance authorization before upgrade operations.".to_string()
         }
         _ => format!("Review and fix the '{}' security pattern.", id),
+    }
+}
+
+fn normalize_severity(severity: &str) -> &'static str {
+    match severity.to_ascii_lowercase().as_str() {
+        "critical" => "critical",
+        "high" => "high",
+        "medium" | "warning" => "medium",
+        "low" => "low",
+        _ => "info",
     }
 }
 
@@ -295,7 +459,7 @@ fn compute_summary(findings: &[VulnerabilityFinding]) -> AuditSummary {
         info: 0,
     };
     for f in findings {
-        match f.severity.as_str() {
+        match normalize_severity(&f.severity) {
             "critical" => s.critical += 1,
             "high" => s.high += 1,
             "medium" => s.medium += 1,
@@ -323,11 +487,13 @@ pub fn format_report(result: &AuditResult) -> String {
          Contract : {}\n\
          Timestamp: {}\n\
          Tools    : {}\n\
-         Score    : {:.1}/100\n\n",
+         Score    : {:.1}/100\n\
+         CI ready : {}\n\n",
         result.contract_path,
         result.timestamp,
         result.tools_used.join(", "),
         result.score,
+        if result.ci_passed { "yes" } else { "no" },
     ));
     out.push_str(&format!(
         "Summary\n\
@@ -343,6 +509,19 @@ pub fn format_report(result: &AuditResult) -> String {
         result.summary.low,
         result.summary.info,
     ));
+    out.push_str("Tool Status\n-----------\n");
+    for tool in &result.tool_statuses {
+        out.push_str(&format!(
+            "- {}: {} (available: {}, findings: {})",
+            tool.tool, tool.status, tool.available, tool.findings
+        ));
+        if let Some(message) = &tool.message {
+            out.push_str(&format!(" - {}", message));
+        }
+        out.push('\n');
+    }
+    out.push('\n');
+
     if result.findings.is_empty() {
         out.push_str("No issues found.\n");
     } else {
@@ -364,6 +543,98 @@ pub fn format_report(result: &AuditResult) -> String {
         }
     }
     out
+}
+
+pub fn format_html_report(result: &AuditResult) -> String {
+    let rows = result
+        .findings
+        .iter()
+        .map(|finding| {
+            format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                html_escape(&finding.severity),
+                html_escape(&finding.tool),
+                html_escape(&finding.title),
+                html_escape(finding.location.as_deref().unwrap_or("")),
+                html_escape(&finding.remediation)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let tool_rows = result
+        .tool_statuses
+        .iter()
+        .map(|tool| {
+            format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                html_escape(&tool.tool),
+                html_escape(&tool.status),
+                tool.findings,
+                html_escape(tool.message.as_deref().unwrap_or(""))
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>Security Audit Report</title></head>
+<body>
+<h1>Security Audit Report</h1>
+<p><strong>Contract:</strong> {}</p>
+<p><strong>Score:</strong> {:.1}/100</p>
+<p><strong>Generated:</strong> {}</p>
+<h2>Tool Status</h2>
+<table border="1"><tr><th>Tool</th><th>Status</th><th>Findings</th><th>Message</th></tr>{}</table>
+<h2>Findings</h2>
+<table border="1"><tr><th>Severity</th><th>Tool</th><th>Title</th><th>Location</th><th>Remediation</th></tr>{}</table>
+</body>
+</html>"#,
+        html_escape(&result.contract_path),
+        result.score,
+        html_escape(&result.timestamp),
+        tool_rows,
+        rows
+    )
+}
+
+pub fn generate_github_actions_workflow(contract_path: &Path, min_score: f64) -> String {
+    format!(
+        r#"name: StarForge Security Audit
+
+on:
+  pull_request:
+  push:
+    branches: [ master, main ]
+
+jobs:
+  security-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install optional audit tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install slither-analyzer mythril || true
+      - name: Build StarForge
+        run: cargo build --locked
+      - name: Run contract security audit
+        run: cargo run -- security audit {} --format json --min-score {:.1} --ci
+"#,
+        contract_path.display(),
+        min_score
+    )
+}
+
+fn html_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }
 
 #[cfg(test)]
@@ -409,7 +680,7 @@ mod tests {
             VulnerabilityFinding {
                 id: "y".to_string(),
                 title: "t2".to_string(),
-                severity: "low".to_string(),
+                severity: "warning".to_string(),
                 description: "d2".to_string(),
                 location: None,
                 tool: "builtin".to_string(),
@@ -418,7 +689,57 @@ mod tests {
         ];
         let s = compute_summary(&findings);
         assert_eq!(s.high, 1);
-        assert_eq!(s.low, 1);
-        assert_eq!(s.critical + s.medium + s.info, 0);
+        assert_eq!(s.medium, 1);
+        assert_eq!(s.critical + s.low + s.info, 0);
+    }
+
+    #[test]
+    fn parses_slither_json() {
+        let raw = r#"{
+          "results": {
+            "detectors": [{
+              "check": "reentrancy-no-eth",
+              "impact": "High",
+              "description": "External call before state update",
+              "elements": [{
+                "source_mapping": {
+                  "filename_used": "src/lib.rs",
+                  "lines": [10, 11]
+                }
+              }]
+            }]
+          }
+        }"#;
+
+        let findings = parse_slither_output(raw).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, "high");
+        assert!(findings[0].remediation.contains("reentrancy"));
+    }
+
+    #[test]
+    fn parses_mythril_json() {
+        let raw = r#"{
+          "issues": [{
+            "title": "Integer Overflow",
+            "severity": "Medium",
+            "description": { "head": "Overflow possible", "tail": "on addition" },
+            "filename": "src/lib.rs",
+            "lineno": 42
+          }]
+        }"#;
+
+        let findings = parse_mythril_output(raw).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].tool, "mythril");
+        assert_eq!(findings[0].location.as_deref(), Some("src/lib.rs:42"));
+    }
+
+    #[test]
+    fn generated_ci_workflow_runs_security_audit() {
+        let workflow =
+            generate_github_actions_workflow(Path::new("contracts/token/src/lib.rs"), 85.0);
+        assert!(workflow.contains("security audit contracts/token/src/lib.rs"));
+        assert!(workflow.contains("--min-score 85.0"));
     }
 }

--- a/src/utils/security/mod.rs
+++ b/src/utils/security/mod.rs
@@ -12,7 +12,10 @@ pub mod threat_intel;
 pub mod validation;
 
 pub use anomaly::{AnomalyDetector, AnomalyFinding};
-pub use audit::{format_report, run_audit, AuditConfig, AuditResult, VulnerabilityFinding};
+pub use audit::{
+    format_html_report, format_report, generate_github_actions_workflow, run_audit, AuditConfig,
+    AuditResult, AuditToolStatus, VulnerabilityFinding,
+};
 pub use checklist::{run_checklist, ChecklistItem, ChecklistResult};
 pub use event_rules::{default_rules, evaluate_event, SecurityEvent, SecurityEventRule};
 pub use hardening::{apply_hardening, HardeningOptions, HardeningResult};

--- a/tests/security_audit_integration.rs
+++ b/tests/security_audit_integration.rs
@@ -1,0 +1,83 @@
+use starforge::utils::security::{
+    format_html_report, format_report, generate_github_actions_workflow, run_audit, AuditConfig,
+};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+const INSECURE_CONTRACT: &str = r#"
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct Token;
+
+#[contractimpl]
+impl Token {
+    pub fn transfer(env: Env, amount: u64) -> u64 {
+        let balance: u64 = env.storage().instance().get(&()).unwrap();
+        balance + amount
+    }
+}
+"#;
+
+fn write_contract() -> NamedTempFile {
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(INSECURE_CONTRACT.as_bytes()).unwrap();
+    file
+}
+
+#[test]
+fn audit_runs_builtin_pipeline_and_records_tool_statuses() {
+    let file = write_contract();
+    let result = run_audit(
+        file.path(),
+        &AuditConfig {
+            run_slither: false,
+            run_mythril: false,
+        },
+    )
+    .unwrap();
+
+    assert!(result.tools_used.contains(&"starforge-builtin".to_string()));
+    assert!(result
+        .tool_statuses
+        .iter()
+        .any(|tool| tool.tool == "starforge-builtin" && tool.executed));
+    assert!(result
+        .tool_statuses
+        .iter()
+        .any(|tool| tool.tool == "slither" && tool.status == "skipped"));
+    assert!(!result.findings.is_empty());
+    assert!(result.score < 100.0);
+}
+
+#[test]
+fn audit_reports_include_remediation_and_tool_status() {
+    let file = write_contract();
+    let result = run_audit(
+        file.path(),
+        &AuditConfig {
+            run_slither: false,
+            run_mythril: false,
+        },
+    )
+    .unwrap();
+
+    let text = format_report(&result);
+    assert!(text.contains("Tool Status"));
+    assert!(text.contains("Remediation"));
+
+    let html = format_html_report(&result);
+    assert!(html.contains("<table"));
+    assert!(html.contains("Security Audit Report"));
+}
+
+#[test]
+fn ci_workflow_generation_invokes_security_audit() {
+    let workflow =
+        generate_github_actions_workflow(std::path::Path::new("contracts/token/src/lib.rs"), 85.0);
+
+    assert!(workflow.contains("StarForge Security Audit"));
+    assert!(workflow.contains("security audit contracts/token/src/lib.rs"));
+    assert!(workflow.contains("--min-score 85.0"));
+}


### PR DESCRIPTION
## Description

Adds contract security audit integration for Soroban contracts, combining StarForge built-in security checks with optional external audit tools like Slither and Mythril. The audit command now supports tool status reporting, security scoring, remediation suggestions, HTML/JSON/text reports, CI failure thresholds, and GitHub Actions workflow generation.

Closes #350

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made

- Added structured audit tool status reporting for built-in checks, Slither, and Mythril
- Improved external tool integration with cross-platform detection and env var overrides
- Added automated vulnerability scanning pipeline with built-in Soroban heuristics always enabled
- Added security score and CI readiness metadata to audit results
- Added HTML audit report generation alongside existing text/JSON output
- Added `--ci`, `--min-score`, `--ci-workflow-out`, and `--track` support to `starforge security audit`
- Added GitHub Actions workflow generation for CI/CD security checks
- Added remediation tracking integration for audit findings
- Updated command reference docs
- Added focused integration tests for audit pipeline, reports, and CI workflow generation

## Testing

```bash
cargo check
cargo test --test security_audit_integration -- --nocapture
cargo test --test security_hardening -- --nocapture
```

## Test Coverage

- Happy path: built-in audit pipeline runs and records tool statuses
- Reports: text and HTML reports include findings, remediation, and tool status
- CI/CD: generated GitHub Actions workflow invokes `starforge security audit`
- Compatibility: existing security hardening tests still pass

## Breaking Changes

None. Existing `security audit` behavior remains available, with additional output formats and CI options.

## Documentation

Updated `docs/COMMAND_REFERENCE.md` with the new security audit commands and examples.
