### PR TITLE
feat: add hardened real-time contract event monitoring

### DIFF
--- a/docs/COMMAND_REFERENCE.md
+++ b/docs/COMMAND_REFERENCE.md
@@ -330,6 +330,48 @@ See [GOVERNANCE.md](GOVERNANCE.md) for the full workflow.
 | `plugin install/list/run` | Dynamic plugin management |
 | `completions <SHELL>` | bash/zsh/fish completions |
 
+### `monitor`
+
+Live monitoring of contracts or wallets, including Soroban event streaming, routing, alerting, persistence, replay, and dashboard output.
+
+| Option | Purpose |
+|--------|---------|
+| `--contract <ID>` | Contract ID to monitor via Soroban RPC |
+| `--events <EVENTS>` | Comma-separated event names to filter |
+| `--type <TYPE>` | Soroban event type filter (`contract`, `system`, `diagnostic`) |
+| `--topic <TOPIC>` | Topic segment matcher, comma-separated, with `*` wildcards |
+| `--value <VALUE>` | Match event payload text |
+| `--transport <TRANSPORT>` | `auto`, `websocket`, or `http` transport selection |
+| `--websocket-url <URL>` | Override the derived WebSocket endpoint |
+| `--route <NAME=PATTERN>` | Route matching events into named lanes; repeatable |
+| `--alert <RULE>` | Alert rule in `pattern`, `severity:pattern`, or `severity:pattern:message` form |
+| `--persist [PATH]` | Persist matching events to JSONL, using the default StarForge event store path when PATH is omitted |
+| `--replay <PATH>` | Replay events from a JSONL event store instead of connecting live |
+| `--dashboard` | Render the event analytics dashboard |
+| `--trigger <PATTERN=COMMAND>` | Execute a shell command when a pattern matches; repeatable |
+| `--allow-triggers` | Required explicit opt-in before event triggers execute shell commands |
+| `--wallet <NAME>` | Wallet name to monitor |
+| `--threshold <AMOUNT>` | XLM threshold for notifications |
+| `--balance-alert <AMOUNT>` | Alert when wallet balance drops below this amount |
+| `--network <NETWORK>` | Network to use |
+| `--interval <SECONDS>` | Poll interval in seconds |
+
+Examples:
+
+```bash
+starforge monitor --contract CCPYZ... --transport websocket --dashboard
+starforge monitor --contract CCPYZ... --route swaps=swap --alert high:mint --persist
+starforge monitor --contract CCPYZ... --replay ~/.starforge/events/testnet-CCPYZ....jsonl --dashboard
+starforge monitor --contract CCPYZ... --trigger mint=./on-mint.sh --allow-triggers
+```
+
+Event stores use JSON Lines. Replay skips malformed records and deduplicates events by
+network, contract ID, and Soroban event ID. Triggers inherit event metadata through
+`STARFORGE_NETWORK`, `STARFORGE_CONTRACT_ID`, `STARFORGE_EVENT_ID`,
+`STARFORGE_EVENT_LEDGER`, `STARFORGE_EVENT_TYPE`, `STARFORGE_EVENT_TOPIC`, and
+`STARFORGE_EVENT_VALUE`. Treat trigger commands as trusted local code; they are disabled
+unless `--allow-triggers` is explicitly provided.
+
 ---
 
 ## External plugins

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -79,6 +79,10 @@ pub struct MonitorArgs {
     #[arg(long = "trigger")]
     pub triggers: Vec<String>,
 
+    /// Explicitly allow configured event triggers to execute shell commands
+    #[arg(long)]
+    pub allow_triggers: bool,
+
     /// Wallet name from starforge config to monitor
     #[arg(long)]
     pub wallet: Option<String>,
@@ -130,6 +134,7 @@ pub async fn handle(args: MonitorArgs) -> Result<()> {
                 args.replay.as_ref(),
                 args.dashboard,
                 &args.triggers,
+                args.allow_triggers,
             )
             .await
         }
@@ -174,6 +179,7 @@ async fn monitor_contract(
     replay: Option<&PathBuf>,
     dashboard: bool,
     trigger_specs: &[String],
+    allow_triggers: bool,
 ) -> Result<()> {
     config::validate_contract_id(contract_id)?;
 
@@ -182,6 +188,9 @@ async fn monitor_contract(
     let router = EventRouter::from_specs(routes)?;
     let alert_engine = AlertEngine::from_specs(alerts)?;
     let triggers = EventTrigger::from_specs(trigger_specs)?;
+    if !triggers.is_empty() && !allow_triggers {
+        anyhow::bail!("event triggers execute shell commands; rerun with --allow-triggers to enable them");
+    }
 
     if let Some(replay_path) = replay {
         return replay_contract_events(

--- a/src/utils/event_monitoring.rs
+++ b/src/utils/event_monitoring.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt::Write as _;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
@@ -176,6 +177,10 @@ impl PersistedEvent {
             event,
         }
     }
+
+    pub fn identity(&self) -> String {
+        format!("{}:{}:{}", self.network, self.contract_id, self.event.id)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -231,6 +236,7 @@ impl EventStore {
         let reader = BufReader::new(file);
         let mut events = Vec::new();
 
+        let mut identities = HashSet::new();
         for (index, line) in reader.lines().enumerate() {
             let line = line.with_context(|| {
                 format!("failed to read line {} from {}", index + 1, self.path.display())
@@ -239,14 +245,21 @@ impl EventStore {
             if trimmed.is_empty() {
                 continue;
             }
-            let event: PersistedEvent = serde_json::from_str(trimmed).with_context(|| {
-                format!(
-                    "failed to parse persisted event on line {} of {}",
-                    index + 1,
-                    self.path.display()
-                )
-            })?;
-            events.push(event);
+            let event: PersistedEvent = match serde_json::from_str(trimmed) {
+                Ok(event) => event,
+                Err(error) => {
+                    eprintln!(
+                        "warning: skipping corrupt persisted event on line {} of {}: {}",
+                        index + 1,
+                        self.path.display(),
+                        error
+                    );
+                    continue;
+                }
+            };
+            if identities.insert(event.identity()) {
+                events.push(event);
+            }
         }
 
         Ok(events)
@@ -464,6 +477,7 @@ fn write_counts(out: &mut String, title: &str, counts: &HashMap<String, usize>) 
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::TempDir;
 
     fn sample_event() -> SorobanEvent {
         SorobanEvent {
@@ -496,5 +510,84 @@ mod tests {
         assert_eq!(alerts.len(), 1);
         assert_eq!(alerts[0].severity, "critical");
         assert_eq!(alerts[0].message, "admin event");
+    }
+
+    #[test]
+    fn event_store_round_trips_persisted_events() {
+        let dir = TempDir::new().unwrap();
+        let store = EventStore::new(dir.path().join("events.jsonl"));
+        let event = sample_event();
+        let persisted = PersistedEvent::new(
+            "testnet",
+            "C123",
+            event,
+            vec!["dex".to_string()],
+            vec![EventAlert {
+                rule_id: "alert-1".to_string(),
+                severity: "high".to_string(),
+                message: "matched event pattern 'swap'".to_string(),
+            }],
+        );
+
+        store.persist(&persisted).unwrap();
+
+        let replayed = store.replay().unwrap();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].network, "testnet");
+        assert_eq!(replayed[0].contract_id, "C123");
+        assert_eq!(replayed[0].routes, vec!["dex".to_string()]);
+        assert_eq!(replayed[0].alerts.len(), 1);
+        assert_eq!(replayed[0].event.id, "0000000042-0000000001");
+    }
+
+    #[test]
+    fn analytics_dashboard_includes_counts_and_recent_events() {
+        let event = sample_event();
+        let persisted = PersistedEvent::new(
+            "testnet",
+            "C123",
+            event,
+            vec!["dex".to_string()],
+            vec![EventAlert {
+                rule_id: "alert-1".to_string(),
+                severity: "critical".to_string(),
+                message: "admin event".to_string(),
+            }],
+        );
+
+        let analytics = EventAnalytics::from_events(&[persisted]);
+        let dashboard = analytics.render_dashboard();
+
+        assert!(dashboard.contains("Event Analytics Dashboard"));
+        assert!(dashboard.contains("Total events : 1"));
+        assert!(dashboard.contains("Alerts fired : 1"));
+        assert!(dashboard.contains("By route:"));
+        assert!(dashboard.contains("Recent events:"));
+    }
+
+    #[test]
+    fn replay_skips_corrupt_and_duplicate_records() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let store = EventStore::new(path.clone());
+        let persisted = PersistedEvent::new(
+            "testnet",
+            "C123",
+            sample_event(),
+            Vec::new(),
+            Vec::new(),
+        );
+        store.persist(&persisted).unwrap();
+        store.persist(&persisted).unwrap();
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"not-json\n")
+            .unwrap();
+
+        let replayed = store.replay().unwrap();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].identity(), "testnet:C123:0000000042-0000000001");
     }
 }

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -458,6 +458,8 @@ pub struct SorobanEvent {
 mod tests {
     use super::*;
     use serde_json::json;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
 
     #[test]
     fn derives_websocket_urls_from_http_rpc_urls() {
@@ -497,5 +499,79 @@ mod tests {
         let result = response.result.unwrap();
         assert_eq!(result.cursor.as_deref(), Some("abc"));
         assert_eq!(result.events.len(), 1);
+    }
+
+    #[test]
+    fn decodes_direct_result_websocket_events() {
+        let message = json!({
+            "jsonrpc": "2.0",
+            "result": {
+                "cursor": "xyz",
+                "events": [{
+                    "type": "contract",
+                    "ledger": 9,
+                    "id": "event-2",
+                    "topic": ["mint"],
+                    "value": {"ok": true}
+                }]
+            }
+        });
+
+        let response = decode_websocket_response(&message.to_string())
+            .unwrap()
+            .unwrap();
+        let result = response.result.unwrap();
+        assert_eq!(result.cursor.as_deref(), Some("xyz"));
+        assert_eq!(result.events[0].id, "event-2");
+    }
+
+    #[test]
+    fn websocket_url_derivation_rejects_unrelated_inputs() {
+        assert!(websocket_url_from_rpc_url("notaurl").is_err());
+    }
+
+    #[tokio::test]
+    async fn websocket_transport_round_trips_get_events() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            let message = socket.next().await.unwrap().unwrap();
+            let request: serde_json::Value = serde_json::from_str(message.to_text().unwrap()).unwrap();
+            assert_eq!(request["method"], "getEvents");
+            socket
+                .send(Message::Text(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request["id"],
+                        "result": {
+                            "cursor": "mock-cursor",
+                            "events": [{
+                                "type": "contract",
+                                "ledger": 12,
+                                "id": "mock-event",
+                                "topic": ["mint"],
+                                "value": {"amount": 10}
+                            }]
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let mut stream = SorobanEventStream::new(
+            format!("http://{}", address),
+            "C123".to_string(),
+        )
+        .with_transport(EventStreamTransport::WebSocket)
+        .with_websocket_url(format!("ws://{}", address));
+        let events = stream.next_batch().await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "mock-event");
+        server.await.unwrap();
     }
 }


### PR DESCRIPTION
## Issue Resolved
Implements real-time Soroban contract event monitoring with WebSocket streaming, event filtering and routing, pattern-based alerts, persistence and replay, analytics, and event-triggered actions.

## Changes
- Add WebSocket `getEvents` transport with HTTP fallback.
- Add event filtering, routing, alerts, persistence, replay, and analytics.
- Deduplicate replayed events and skip corrupt JSONL records.
- Require explicit `--allow-triggers` opt-in for shell triggers.
- Add local WebSocket protocol coverage and CLI documentation.

## Validation
- `cargo check --lib` passes.
- Full repository tests remain blocked by the pre-existing `soroban-env-host` / `ed25519-dalek` dependency incompatibility.

Closes #326